### PR TITLE
Form Objects based on prototype version 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ coverage
 .DS_Store
 .env
 spec/dummy/.byebug_history
+
+.idea

--- a/app/forms/flood_risk_engine/steps/add_exemptions_form.rb
+++ b/app/forms/flood_risk_engine/steps/add_exemptions_form.rb
@@ -1,0 +1,30 @@
+module FloodRiskEngine
+  module Steps
+
+    class AddExemptionForm < FloodRiskEngine::Steps::BaseForm
+      def self.factory(enrollment)
+        new(enrollment)
+      end
+
+      def initialize(enrollment)
+        super  enrollment
+        @exemptions = Exemption.all
+      end
+
+      attr_reader :exemptions
+
+      def params_key
+        :add_exemptions_id
+      end
+
+      def save
+        super
+      end
+
+      collection :exemptions do
+        property :code
+      end
+
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/steps/applicant_contact_email_form.rb
+++ b/app/forms/flood_risk_engine/steps/applicant_contact_email_form.rb
@@ -1,0 +1,21 @@
+module FloodRiskEngine
+  module Steps
+    class ApplicantContactEmailForm < BaseForm
+
+      property :email_address
+
+      def self.factory(enrollment)
+        contact = enrollment.applicant_contact || Contact.new
+        new(contact, enrollment)
+      end
+
+      def params_key
+        :applicant_contact_email
+      end
+
+      def save
+        super
+      end
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/steps/applicant_contact_form.rb
+++ b/app/forms/flood_risk_engine/steps/applicant_contact_form.rb
@@ -1,0 +1,23 @@
+module FloodRiskEngine
+  module Steps
+    class ApplicantContactForm < BaseForm
+
+      # Define the attributes on the inbound model, that you want included in your form/validation with
+      # property :name
+      # For full API see  - https://github.com/apotonick/reform
+
+      def self.factory(enrollment)
+        contact = enrollment.applicant_contact || Contact.new
+        new(contact, enrollment)
+      end
+
+      def params_key
+        :applicant_contact
+      end
+
+      def save
+        super
+      end
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/steps/applicant_contact_name_form.rb
+++ b/app/forms/flood_risk_engine/steps/applicant_contact_name_form.rb
@@ -1,0 +1,24 @@
+module FloodRiskEngine
+  module Steps
+    class ApplicantContactNameForm < BaseForm
+
+      # Define the attributes on the inbound model, that you want included in your form/validation with
+      # property :name
+      # For full API see  - https://github.com/apotonick/reform
+        property :full_name
+
+      def self.factory(enrollment)
+        contact = enrollment.applicant_contact || Contact.new
+        new(contact, enrollment)
+      end
+
+      def params_key
+        :applicant_contact_name
+      end
+
+      def save
+        super
+      end
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/steps/applicant_contact_telephone_form.rb
+++ b/app/forms/flood_risk_engine/steps/applicant_contact_telephone_form.rb
@@ -1,0 +1,25 @@
+module FloodRiskEngine
+  module Steps
+    class ApplicantContactTelephoneForm < BaseForm
+
+      # Define the attributes on the inbound model, that you want included in your form/validation with
+      # property :name
+      # For full API see  - https://github.com/apotonick/reform
+        property :phone_numbers
+
+      def self.factory(enrollment)
+        contact = enrollment.correspondence_contact || ::Contact.new
+        contact.phone_number = PhoneNumber.new
+        new(contact, enrollment)
+      end
+
+      def params_key
+        :applicant_contact_telephone
+      end
+
+      def save
+        super
+      end
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/steps/applicant_contact_telephone_form.rb
+++ b/app/forms/flood_risk_engine/steps/applicant_contact_telephone_form.rb
@@ -5,7 +5,7 @@ module FloodRiskEngine
       # Define the attributes on the inbound model, that you want included in your form/validation with
       # property :name
       # For full API see  - https://github.com/apotonick/reform
-        property :phone_numbers
+        property :phone_number
 
       def self.factory(enrollment)
         contact = enrollment.correspondence_contact || ::Contact.new

--- a/app/forms/flood_risk_engine/steps/check_exemptions_form.rb
+++ b/app/forms/flood_risk_engine/steps/check_exemptions_form.rb
@@ -1,0 +1,22 @@
+module FloodRiskEngine
+  module Steps
+    class CheckExemptionForm < BaseForm
+
+      # Define the attributes on the inbound model, that you want included in your form/validation with
+      # property :name
+      # For full API see  - https://github.com/apotonick/reform
+
+      def self.factory(enrollment)
+        new(enrollment)
+      end
+
+      def params_key
+        :check_exemptions
+      end
+
+      def save
+        super
+      end
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/steps/confirmation_form.rb
+++ b/app/forms/flood_risk_engine/steps/confirmation_form.rb
@@ -1,0 +1,22 @@
+module FloodRiskEngine
+  module Steps
+    class ConfirmationForm < BaseForm
+
+      # Define the attributes on the inbound model, that you want included in your form/validation with
+      # property :name
+      # For full API see  - https://github.com/apotonick/reform
+
+      def self.factory(enrollment)
+        new(enrollment)
+      end
+
+      def params_key
+        :confirmation
+      end
+
+      def save
+        super
+      end
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/steps/declaration_form.rb
+++ b/app/forms/flood_risk_engine/steps/declaration_form.rb
@@ -1,0 +1,22 @@
+module FloodRiskEngine
+  module Steps
+    class DeclarationForm < BaseForm
+
+      # Define the attributes on the inbound model, that you want included in your form/validation with
+      # property :name
+      # For full API see  - https://github.com/apotonick/reform
+
+      def self.factory(enrollment)
+        new(enrollment)
+      end
+
+      def params_key
+        :declaration
+      end
+
+      def save
+        super
+      end
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/steps/grid_reference_form.rb
+++ b/app/forms/flood_risk_engine/steps/grid_reference_form.rb
@@ -1,6 +1,6 @@
 module FloodRiskEngine
   module Steps
-    class ActivityLocationForm < BaseForm
+    class GridReferenceForm < BaseForm
       property :grid_reference
       validates :grid_reference, presence: true
 

--- a/app/forms/flood_risk_engine/steps/grid_reference_form.rb
+++ b/app/forms/flood_risk_engine/steps/grid_reference_form.rb
@@ -10,7 +10,10 @@ module FloodRiskEngine
       # be initialised like so
       #   Step1Form.new(enrollment.address, enrollment)
       def self.factory(enrollment)
-        new(Location.new, enrollment)
+
+        # TODO: what happens if they click back ? get the site address ?
+        location = Location.new  # enrollment.site_address || Location.new
+        new(location, enrollment)
       end
 
       def params_key

--- a/app/forms/flood_risk_engine/steps/individual_name_form.rb
+++ b/app/forms/flood_risk_engine/steps/individual_name_form.rb
@@ -1,0 +1,24 @@
+module FloodRiskEngine
+  module Steps
+    class IndividualNameForm < BaseForm
+
+      # Define the attributes on the inbound model, that you want included in your form/validation with
+      # property :name
+      # For full API see  - https://github.com/apotonick/reform
+        property :full_name
+
+      def self.factory(enrollment)
+        contact = enrollment.applicant_contact || ::Contact.new
+        new(contact, enrollment)
+      end
+
+      def params_key
+        :individual_name
+      end
+
+      def save
+        super
+      end
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/steps/individual_postcode_form.rb
+++ b/app/forms/flood_risk_engine/steps/individual_postcode_form.rb
@@ -1,0 +1,28 @@
+module FloodRiskEngine
+  module Steps
+    class IndividualPostcodeForm < BaseForm
+
+      # Define the attributes on the inbound model, that you want included in your form/validation with
+      # property :name
+      # For full API see  - https://github.com/apotonick/reform
+        property :postcode
+        property :premises
+        property :street_address
+        property :locality
+        property :city
+
+      def self.factory(enrollment)
+        address =  Address.new
+        new(address, enrollment)
+      end
+
+      def params_key
+        :individual_postcode
+      end
+
+      def save
+        super
+      end
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/steps/main_contact_address_form.rb
+++ b/app/forms/flood_risk_engine/steps/main_contact_address_form.rb
@@ -1,0 +1,26 @@
+module FloodRiskEngine
+  module Steps
+    class MainContactAddressForm < BaseForm
+
+      # For full API see  - https://github.com/apotonick/reform
+        property :postcode
+        property :premises
+        property :street_address
+        property :locality
+        property :city
+
+      def self.factory(enrollment)
+        address =  Address.new
+        new(address, enrollment)
+      end
+
+      def params_key
+        :main_contact_address
+      end
+
+      def save
+        super
+      end
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/steps/main_contact_email_form.rb
+++ b/app/forms/flood_risk_engine/steps/main_contact_email_form.rb
@@ -1,0 +1,22 @@
+module FloodRiskEngine
+  module Steps
+    class MainContactEmailForm < BaseForm
+
+      # For full API see  - https://github.com/apotonick/reform
+      property :email_address
+
+      def self.factory(enrollment)
+        contact = enrollment.correspondence_contact || Contact.new
+        new(contact, enrollment)
+      end
+
+      def params_key
+        :main_contact_email
+      end
+
+      def save
+        super
+      end
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/steps/main_contact_name_form.rb
+++ b/app/forms/flood_risk_engine/steps/main_contact_name_form.rb
@@ -1,0 +1,25 @@
+module FloodRiskEngine
+  module Steps
+    class MainContactNameForm < BaseForm
+
+      # Define the attributes on the inbound model, that you want included in your form/validation with
+      # property :name
+      # For full API see  - https://github.com/apotonick/reform
+        property :full_name
+        property :position
+
+      def self.factory(enrollment)
+        contact = enrollment.correspondence_contact || Contact.new
+        new(contact, enrollment)
+      end
+
+      def params_key
+        :main_contact_name
+      end
+
+      def save
+        super
+      end
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/steps/main_contact_telephone_form.rb
+++ b/app/forms/flood_risk_engine/steps/main_contact_telephone_form.rb
@@ -1,0 +1,25 @@
+module FloodRiskEngine
+  module Steps
+    class MainContactTelephoneForm < BaseForm
+
+      # Define the attributes on the inbound model, that you want included in your form/validation with
+      # property :name
+      # For full API see  - https://github.com/apotonick/reform
+        property :phone_numbers
+
+      def self.factory(enrollment)
+        contact = enrollment.correspondence_contact || Contact.new
+        contact.phone_number = PhoneNumber.new
+        new(contact, enrollment)
+      end
+
+      def params_key
+        :main_contact_telephone
+      end
+
+      def save
+        super
+      end
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/steps/main_contact_telephone_form.rb
+++ b/app/forms/flood_risk_engine/steps/main_contact_telephone_form.rb
@@ -5,7 +5,7 @@ module FloodRiskEngine
       # Define the attributes on the inbound model, that you want included in your form/validation with
       # property :name
       # For full API see  - https://github.com/apotonick/reform
-        property :phone_numbers
+        property :phone_number
 
       def self.factory(enrollment)
         contact = enrollment.correspondence_contact || Contact.new

--- a/app/forms/flood_risk_engine/steps/reviewing_form.rb
+++ b/app/forms/flood_risk_engine/steps/reviewing_form.rb
@@ -1,0 +1,31 @@
+module FloodRiskEngine
+  module Steps
+    class ReviewingForm < BaseForm
+
+      # Define the attributes on the inbound model, that you want included in your form/validation with
+      # property :name
+      # For full API see  - https://github.com/apotonick/reform
+
+      def self.factory(enrollment)
+
+        def initialize(enrollment)
+          super  enrollment
+          @enrollment_review = DigitalServicesCore::EnrollmentReview.new(enrollment)
+          @review_data_sections = @enrollment_review.prepare_review_data_list
+        end
+
+        new(enrollment)
+      end
+
+      attr_reader :enrollment_review, :review_data_sections
+
+      def params_key
+        :check_your_answers
+      end
+
+      def save
+        super
+      end
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/steps/user_type_form.rb
+++ b/app/forms/flood_risk_engine/steps/user_type_form.rb
@@ -1,6 +1,7 @@
 module FloodRiskEngine
   module Steps
-    class OrganisationTypeForm < BaseForm
+    class UserTypeForm < BaseForm
+
       property :type
       validates :type, presence: true
 

--- a/lib/flood_risk_engine/engine.rb
+++ b/lib/flood_risk_engine/engine.rb
@@ -11,5 +11,13 @@ module FloodRiskEngine
     initializer :add_i18n_load_paths do |app|
       app.config.i18n.load_path += Dir[config.root.join("config/locales/**/**/", "*.{rb,yml}").to_s]
     end
+
+    # Export our form objects to the APPS
+    config.to_prepare do
+      Dir.glob(File.join(Engine.root, "app/forms", "**/*.rb")).each do |c|
+        Rails.configuration.cache_classes ? require(c) : load(c)
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Create form objects for individual journey based on prototype version 1

Create one form object per state, and initialize with best guess at model and attributes, ready to be refined once the modelling redone