### PR TITLE
Add integration to travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: ruby
+cache: bundler
+
+rvm:
+  - 2.2.3
+
+before_script:
+  - cp spec/dummy/config/database.travis.yml spec/dummy/config/database.yml
+
+# Have this option to stop travis-ci building twice. Currently we have travis set to build both
+# PR's and pushes. However this means when we push to a PR we have to wait for Travis to finish
+# 2 builds. If we unticked 'pushes' when the PR was finally merged that would not be built. The
+# brute force approach would be to untick build PR's and just build all pushes. We instead have
+# gone with the approach outlined here http://stackoverflow.com/a/31882307
+branches:
+  only:
+    - master
+    - develop

--- a/README.md
+++ b/README.md
@@ -1,31 +1,24 @@
-FloodRiskEngine
-===============
+# FloodRiskEngine
 
 [![Build Status](https://travis-ci.org/EnvironmentAgency/flood-risk-engine.svg?branch=develop)](https://travis-ci.org/EnvironmentAgency/flood-risk-engine)
 
-Development
------------
+## Development
 
-Before making changes for the first time, please run the
-before_commit rake task to install `overcommit` and the
-associated tasks
+Before making changes for the first time, please run the before_commit rake task to install `overcommit` and the associated tasks
 
 ```bash
 rake app:before_commit:run
 ```
 
-And use before_commit to keep the overcommit configuration
-up to date.
+And use before_commit to keep the overcommit configuration up to date.
 
-Contributing to this project
-----------------------------
+## Contributing to this project
 
 If you have an idea you'd like to contribute please log an issue.
 
 All contributions should be submitted via a pull request.
 
-License
--------
+## License
 
 THIS INFORMATION IS LICENSED UNDER THE CONDITIONS OF THE OPEN GOVERNMENT LICENCE found at:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 FloodRiskEngine
 ===============
 
-
+[![Build Status](https://travis-ci.org/EnvironmentAgency/flood-risk-engine.svg?branch=develop)](https://travis-ci.org/EnvironmentAgency/flood-risk-engine)
 
 Development
 -----------

--- a/spec/dummy/config/database.travis.yml
+++ b/spec/dummy/config/database.travis.yml
@@ -1,0 +1,7 @@
+# In travis-ci this file is copied over the database.yml before the tests are run.
+# As per https://docs.travis-ci.com/user/database-setup/#SQLite3 if you use activerecord they recommend adding the
+# following configuration for your test database.
+test:
+  adapter: sqlite3
+  database: ":memory:"
+  timeout: 500


### PR DESCRIPTION
We believe its important to build CI into your development process, and use [Travis-CI](https://travis-ci.org/) for our open source projects as its free, flexible and simple to use.

This change adds everything required to integrate the project with Travis-CI, and get it automatically building our PR's and branches. It includes

- addition of a `.travis.yml` build config file
- adding a badge to `README.md` to display the current build status of the project
