### PR TITLE
Add missing db indexes and relationships

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,6 @@ source "https://rubygems.org"
 # development dependencies will be added by default to the :development group.
 gemspec
 
-# Declare any dependencies that are still in development here instead of in
-# your gemspec. These might include edge Rails or gems from your path or
-# Git. Remember to move these dependencies to your gemspec before releasing
-# your gem to rubygems.org.
-
 group :test do
   gem "rspec-rails", "~> 3.4"
   gem "factory_girl_rails", "~> 4.6"

--- a/app/models/flood_risk_engine/address.rb
+++ b/app/models/flood_risk_engine/address.rb
@@ -1,7 +1,7 @@
 module FloodRiskEngine
   class Address < ActiveRecord::Base
     belongs_to :contact
-    has_one :location
-    has_one :enrollment, inverse_of: :site_address
+    has_one :location, dependent: :restrict_with_exception
+    has_one :enrollment, inverse_of: :site_address, dependent: :restrict_with_exception
   end
 end

--- a/app/models/flood_risk_engine/enrollment.rb
+++ b/app/models/flood_risk_engine/enrollment.rb
@@ -11,10 +11,8 @@ module FloodRiskEngine
 
     has_many :enrollment_exemptions, foreign_key: :enrollment_id,
              dependent: :restrict_with_exception
-    accepts_nested_attributes_for :enrollment_exemptions
-
-    has_many :exemptions, through: :enrollment_exemptions, dependent: :restrict_with_exception
-    accepts_nested_attributes_for :exemptions
+    has_many :exemptions, through: :enrollment_exemptions,
+             dependent: :restrict_with_exception
 
     serialize :step_history, Array
 

--- a/app/models/flood_risk_engine/enrollment_exemption.rb
+++ b/app/models/flood_risk_engine/enrollment_exemption.rb
@@ -3,7 +3,6 @@ module FloodRiskEngine
     self.table_name = "flood_risk_engine_enrollments_exemptions"
 
     belongs_to :enrollment, foreign_key: :enrollment_id
-
     belongs_to :exemption
   end
 end

--- a/app/models/flood_risk_engine/exemption.rb
+++ b/app/models/flood_risk_engine/exemption.rb
@@ -1,9 +1,9 @@
 module FloodRiskEngine
   class Exemption < ActiveRecord::Base
-    has_many :enrollment_exemptions, dependent: :restrict_with_exception
-    accepts_nested_attributes_for :enrollment_exemptions
-
-    has_many :enrollments, through: :enrollment_exemptions, dependent: :restrict_with_exception
+    has_many :enrollment_exemptions,
+             dependent: :restrict_with_exception
+    has_many :enrollments, through: :enrollment_exemptions,
+             dependent: :restrict_with_exception
 
     enum category: {
     }

--- a/db/migrate/20160415200213_add_missing_indexes.rb
+++ b/db/migrate/20160415200213_add_missing_indexes.rb
@@ -1,0 +1,16 @@
+class AddMissingIndexes < ActiveRecord::Migration
+  def change
+    add_index :flood_risk_engine_enrollments, :applicant_contact_id
+    add_index :flood_risk_engine_enrollments, :organisation_id
+    add_index :flood_risk_engine_enrollments, :site_address_id
+    add_index :flood_risk_engine_contacts,
+              :partnership_organisation_id,
+              name: "fre_contacts_partnership_organisation_id"
+    add_index :flood_risk_engine_organisations, :contact_id
+    add_index :flood_risk_engine_organisations, :type
+    add_index :flood_risk_engine_enrollments_exemptions,
+              [:enrollment_id, :exemption_id],
+              unique: true,
+              name: "fre_enrollments_exemptions_enrollment_id_exemption_id"
+  end
+end

--- a/db/migrate/20160415202953_remove_dummy_enrollment_columns.rb
+++ b/db/migrate/20160415202953_remove_dummy_enrollment_columns.rb
@@ -1,0 +1,7 @@
+class RemoveDummyEnrollmentColumns < ActiveRecord::Migration
+  def change
+    remove_column :flood_risk_engine_enrollments, :dummy_boolean
+    remove_column :flood_risk_engine_enrollments, :dummy_string1
+    remove_column :flood_risk_engine_enrollments, :dummy_string2
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -47,11 +47,9 @@ ActiveRecord::Schema.define(version: 201604131212938) do
   end
 
   add_index "flood_risk_engine_contacts", ["email_address"], name: "index_flood_risk_engine_contacts_on_email_address"
+  add_index "flood_risk_engine_contacts", ["partnership_organisation_id"], name: "fre_contacts_partnership_organisation_id"
 
   create_table "flood_risk_engine_enrollments", force: :cascade do |t|
-    t.boolean  "dummy_boolean"
-    t.string   "dummy_string1"
-    t.string   "dummy_string2"
     t.integer  "applicant_contact_id"
     t.datetime "created_at",                      null: false
     t.datetime "updated_at",                      null: false
@@ -60,6 +58,10 @@ ActiveRecord::Schema.define(version: 201604131212938) do
     t.integer  "site_address_id"
   end
 
+  add_index "flood_risk_engine_enrollments", ["applicant_contact_id"], name: "index_flood_risk_engine_enrollments_on_applicant_contact_id"
+  add_index "flood_risk_engine_enrollments", ["organisation_id"], name: "index_flood_risk_engine_enrollments_on_organisation_id"
+  add_index "flood_risk_engine_enrollments", ["site_address_id"], name: "index_flood_risk_engine_enrollments_on_site_address_id"
+
   create_table "flood_risk_engine_enrollments_exemptions", force: :cascade do |t|
     t.integer  "enrollment_id",             null: false
     t.integer  "exemption_id",              null: false
@@ -67,6 +69,8 @@ ActiveRecord::Schema.define(version: 201604131212938) do
     t.datetime "expires_at"
     t.datetime "valid_from"
   end
+
+  add_index "flood_risk_engine_enrollments_exemptions", %w(enrollment_id exemption_id), name: "fre_enrollments_exemptions_enrollment_id_exemption_id", unique: true
 
   create_table "flood_risk_engine_exemptions", force: :cascade do |t|
     t.string   "code"
@@ -95,6 +99,9 @@ ActiveRecord::Schema.define(version: 201604131212938) do
     t.datetime "created_at",     null: false
     t.datetime "updated_at",     null: false
   end
+
+  add_index "flood_risk_engine_organisations", ["contact_id"], name: "index_flood_risk_engine_organisations_on_contact_id"
+  add_index "flood_risk_engine_organisations", ["type"], name: "index_flood_risk_engine_organisations_on_type"
 
   create_table "not_in_engines", force: :cascade do |t|
     t.string   "name"

--- a/spec/factories/flood_risk_engine_enrollments.rb
+++ b/spec/factories/flood_risk_engine_enrollments.rb
@@ -1,7 +1,4 @@
 FactoryGirl.define do
   factory :enrollment, class: "FloodRiskEngine::Enrollment" do
-    dummy_boolean true
-    dummy_string1 Faker::Lorem.sentence(3)
-    dummy_string2 Faker::Lorem.sentence(3)
   end
 end

--- a/spec/models/flood_risk_engine/address_spec.rb
+++ b/spec/models/flood_risk_engine/address_spec.rb
@@ -3,5 +3,6 @@ require "rails_helper"
 module FloodRiskEngine
   RSpec.describe Address, type: :model do
     it { is_expected.to belong_to(:contact) }
+    it { is_expected.to have_one(:location).dependent(:restrict_with_exception) }
   end
 end

--- a/spec/models/flood_risk_engine/exemption_spec.rb
+++ b/spec/models/flood_risk_engine/exemption_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe Exemption, type: :model do
+    it { is_expected.to be_valid }
+    it { is_expected.to have_many(:enrollment_exemptions).dependent(:restrict_with_exception) }
+    it { is_expected.to have_many(:enrollments).through(:enrollment_exemptions) }
+  end
+end

--- a/spec/models/flood_risk_engine/location.rb
+++ b/spec/models/flood_risk_engine/location.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 module FloodRiskEngine
   RSpec.describe Location, type: :model do
-    # let(:address) { build(:address) }
-    # it { is_expected.to belong_to(:contact) }
+    it { is_expected.to belong_to(:address) }
   end
 end


### PR DESCRIPTION
- Add database indexes
- Remove dummy enrollment columns from the prototyping phase
- Add `dependent:` to has_*
- Removed `accepts_nested_attributes_for` calls as our form object approach has hopefully removed the need for them