### PR TITLE
Allow a user to define organisation type at user_type step

### DIFF
--- a/app/forms/flood_risk_engine/steps/user_type_form.rb
+++ b/app/forms/flood_risk_engine/steps/user_type_form.rb
@@ -1,8 +1,8 @@
 module FloodRiskEngine
   module Steps
     class UserTypeForm < BaseForm
-      property :type
-      validates :type, presence: true
+      property :org_type
+      validates :org_type, presence: true
 
       def self.factory(enrollment)
         organisation = enrollment.organisation || Organisation.new
@@ -20,35 +20,18 @@ module FloodRiskEngine
       # organisation to the correct type; organisation.type is saved implicitly
       # when we save the enrollment
       def save
-        enrollment.organisation = organisation_cast_to_the_chosen_sti_type
+        model.org_type = org_type.to_sym
+        enrollment.organisation = model
         enrollment.save
       end
 
-      # Readonly array of array of organisation types which can be used in radio button
-      # groups. Example output:
-      # [
-      #   [
-      #     FloodRiskEngine::OrganisationTypes::Individual,
-      #     'Individual'
-      #   ],
-      #   [...]
-      # ]
-      #
       def organisation_types
-        Organisation::TYPES.map do |organsation_sti_class|
-          i18n_key = organsation_sti_class.name.demodulize.underscore
+        Organisation.org_types.keys.collect do |org_type|
           [
-            organsation_sti_class.to_s,
-            I18n.translate(i18n_key, scope: "organisation_types")
+            org_type,
+            Organisation.human_attribute_name(org_type)
           ]
         end
-      end
-
-      private
-
-      def organisation_cast_to_the_chosen_sti_type
-        organisation_sti_class = FloodRiskEngine.const_get(type)
-        model.becomes(organisation_sti_class)
       end
     end
   end

--- a/app/models/flood_risk_engine/organisation.rb
+++ b/app/models/flood_risk_engine/organisation.rb
@@ -3,17 +3,13 @@ module FloodRiskEngine
     belongs_to :contact
     has_one :enrollment, dependent: :restrict_with_exception
 
-    TYPES = [
-      OrganisationTypes::LocalAuthority,
-      OrganisationTypes::LimitedCompany,
-      OrganisationTypes::LimitedLiabilityPartnership,
-      OrganisationTypes::Individual,
-      OrganisationTypes::Other,
-      OrganisationTypes::Unknown
-    ].freeze
-
-    def type_name
-      type.split("::").last
-    end
+    enum org_type: {
+      local_authority: 0,
+      limited_company: 1,
+      limited_liability_partnership: 2,
+      individual: 3,
+      other: 4,
+      unknown: 5
+    }
   end
 end

--- a/app/models/flood_risk_engine/organisation_types/individual.rb
+++ b/app/models/flood_risk_engine/organisation_types/individual.rb
@@ -1,6 +1,0 @@
-module FloodRiskEngine
-  module OrganisationTypes
-    class Individual < Organisation
-    end
-  end
-end

--- a/app/models/flood_risk_engine/organisation_types/limited_company.rb
+++ b/app/models/flood_risk_engine/organisation_types/limited_company.rb
@@ -1,6 +1,0 @@
-module FloodRiskEngine
-  module OrganisationTypes
-    class LimitedCompany < Organisation
-    end
-  end
-end

--- a/app/models/flood_risk_engine/organisation_types/limited_liability_partnership.rb
+++ b/app/models/flood_risk_engine/organisation_types/limited_liability_partnership.rb
@@ -1,6 +1,0 @@
-module FloodRiskEngine
-  module OrganisationTypes
-    class LimitedLiabilityPartnership < Organisation
-    end
-  end
-end

--- a/app/models/flood_risk_engine/organisation_types/local_authority.rb
+++ b/app/models/flood_risk_engine/organisation_types/local_authority.rb
@@ -1,6 +1,0 @@
-module FloodRiskEngine
-  module OrganisationTypes
-    class LocalAuthority < Organisation
-    end
-  end
-end

--- a/app/models/flood_risk_engine/organisation_types/other.rb
+++ b/app/models/flood_risk_engine/organisation_types/other.rb
@@ -1,6 +1,0 @@
-module FloodRiskEngine
-  module OrganisationTypes
-    class Other < Organisation
-    end
-  end
-end

--- a/app/models/flood_risk_engine/organisation_types/partnership.rb
+++ b/app/models/flood_risk_engine/organisation_types/partnership.rb
@@ -1,6 +1,0 @@
-module FloodRiskEngine
-  module OrganisationTypes
-    class Partnership < Organisation
-    end
-  end
-end

--- a/app/models/flood_risk_engine/organisation_types/unknown.rb
+++ b/app/models/flood_risk_engine/organisation_types/unknown.rb
@@ -1,6 +1,0 @@
-module FloodRiskEngine
-  module OrganisationTypes
-    class Unknown < Organisation
-    end
-  end
-end

--- a/app/views/flood_risk_engine/enrollments/steps/_user_type.html.erb
+++ b/app/views/flood_risk_engine/enrollments/steps/_user_type.html.erb
@@ -1,5 +1,16 @@
 <%= f.label :organisation_type %>
-<%#= f.collection_radio_buttons :type,
-                               form.organisation_types,
-                               :first,
-                               :last %>
+<ul>
+<%= f.collection_radio_buttons(
+      :org_type,
+      form.organisation_types,
+      :first,
+      :last
+    ) do |b|
+      content_tag(
+        'li',
+        b.label{ b.radio_button + b.text },
+        class: "list-unstyled"
+      )
+    end
+%>
+</ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,10 @@
+en:
+  activerecord:
+    attributes:
+      flood_risk_engine/organisation:
+        local_authority: Local Authority
+        individual: Individual
+        limited_company: Limited Company
+        limited_liability_partnership: Limited Liability Partnership
+        other: Other
+        unknown: Unknown

--- a/config/locales/organisation_types.en.yml
+++ b/config/locales/organisation_types.en.yml
@@ -1,8 +1,0 @@
-en:
-  organisation_types:
-    local_authority: Local Authority
-    individual: Individual
-    limited_company: Limited Company
-    limited_liability_partnership: Limited Liability Partnership
-    other: Other
-    unknown: Unknown

--- a/db/migrate/20160419132958_replace_type_with_org_type_for_organisations.rb
+++ b/db/migrate/20160419132958_replace_type_with_org_type_for_organisations.rb
@@ -1,0 +1,15 @@
+class ReplaceTypeWithOrgTypeForOrganisations < ActiveRecord::Migration
+  def up
+    remove_index :flood_risk_engine_organisations, :type
+    remove_column :flood_risk_engine_organisations, :type
+    add_column :flood_risk_engine_organisations, :org_type, :integer
+    add_index :flood_risk_engine_organisations, :org_type
+  end
+
+  def down
+    remove_index :flood_risk_engine_organisations, :org_type
+    remove_column :flood_risk_engine_organisations, :org_type
+    add_column :flood_risk_engine_organisations, :type, :string
+    add_index :flood_risk_engine_organisations, :type
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -93,16 +93,16 @@ ActiveRecord::Schema.define(version: 201604131212938) do
   add_index "flood_risk_engine_locations", ["address_id"], name: "index_flood_risk_engine_locations_on_address_id"
 
   create_table "flood_risk_engine_organisations", force: :cascade do |t|
-    t.string   "type"
     t.string   "name"
     t.integer  "contact_id"
     t.string   "company_number"
     t.datetime "created_at",     null: false
     t.datetime "updated_at",     null: false
+    t.integer  "org_type"
   end
 
   add_index "flood_risk_engine_organisations", ["contact_id"], name: "index_flood_risk_engine_organisations_on_contact_id"
-  add_index "flood_risk_engine_organisations", ["type"], name: "index_flood_risk_engine_organisations_on_type"
+  add_index "flood_risk_engine_organisations", ["org_type"], name: "index_flood_risk_engine_organisations_on_org_type"
 
   create_table "not_in_engines", force: :cascade do |t|
     t.string   "name"

--- a/spec/factories/organisations.rb
+++ b/spec/factories/organisations.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :organisation, class: "FloodRiskEngine::Organisation" do
-    org_type :other
+    org_type 0
     name Faker::Company.name
     contact_id 1
     company_number Faker::Number.number(8)

--- a/spec/factories/organisations.rb
+++ b/spec/factories/organisations.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :organisation, class: "FloodRiskEngine::Organisation" do
-    type Faker::Company.profession
+    org_type :other
     name Faker::Company.name
     contact_id 1
     company_number Faker::Number.number(8)

--- a/spec/forms/flood_risk_engine/user_type_form_spec.rb
+++ b/spec/forms/flood_risk_engine/user_type_form_spec.rb
@@ -12,20 +12,31 @@ module FloodRiskEngine
     it_behaves_like "a form object"
 
     it { is_expected.to be_a(described_class) }
-    it { is_expected.to respond_to(:type) }
-    it { is_expected.to validate_presence_of(:type) }
+    it { is_expected.to respond_to(:org_type) }
+    it { is_expected.to validate_presence_of(:org_type) }
 
-    describe "#save" do
-      it "saves the enrollment.organisation with the correct STI type" do
-        sti_type = FloodRiskEngine::OrganisationTypes::Individual
-        params = { params_key => { type: sti_type.to_s } }
+    describe ".save" do
+      let(:params) { { params_key => { org_type: org_type } } }
+      let(:org_type) { Organisation.org_types.keys.first }
 
-        expect(enrollment).to receive(:save).and_return(true) # stub save
+      def validate_and_save
+        expect(subject.validate(params)).to be(true)
+        expect(subject.save).to be(true)
+      end
 
-        subject.validate(params)
-        subject.save
+      it "saves the enrollment" do
+        expect(enrollment).to receive(:save).and_return(true)
+        validate_and_save
+      end
 
-        expect(enrollment.organisation).to be_a(sti_type)
+      it "saves the organisation" do
+        expect(subject.model).to receive(:save).and_return(true)
+        validate_and_save
+      end
+
+      it "sets the enrollment.organisation to the correct org_type" do
+        expect(subject.validate(params)).to be(true)
+        validate_and_save
       end
     end
   end


### PR DESCRIPTION
Use an ActiveRecord `enum` to define organisation types, as validation has moved to the form object.