### PR TITLE
Rename migration to remove invalid timestamp

### DIFF
--- a/db/migrate/20160413121293_create_exemptions.rb
+++ b/db/migrate/20160413121293_create_exemptions.rb
@@ -8,7 +8,7 @@ class CreateExemptions < ActiveRecord::Migration
       t.timestamps null: false
     end
 
-    create_table :flood_risk_engine_enrollments_exemptions, force: :cascade do |t|
+    create_table :flood_risk_engine_enrollments_exemptions do |t|
       t.references  :enrollment,      null: false
       t.references  :exemption,       null: false
       t.integer  :status,             default: 0


### PR DESCRIPTION
This migration had an extra number in the timestamp
in the filename and was preventing the migration from running
when mounted in a host application.