### PR TITLE
Refactor to match new rubocop standards

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :test do
   gem "shoulda-matchers", "~> 3.1", require: false
   gem "poltergeist", "~> 1.9" # Needed for headless testing with Javascript or pages that ref external sites
   gem "capybara", "~> 2.6"
-  gem 'guard-rspec', require: false
-  gem 'rspec-html-matchers'
+  gem "guard-rspec", require: false
+  gem "rspec-html-matchers"
   gem "database_cleaner", "~> 1.5"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,7 +51,7 @@ GEM
     ast (2.2.0)
     autoprefixer-rails (6.3.6)
       execjs
-    before_commit (0.4.0)
+    before_commit (0.6.1)
     bootstrap-sass (3.3.6)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)

--- a/app/factories/flood_risk_engine/steps/form_object_factory.rb
+++ b/app/factories/flood_risk_engine/steps/form_object_factory.rb
@@ -4,11 +4,12 @@ module FloodRiskEngine
       class << self
         def form_object_for(step, enrollment)
           klass = form_object_class_map.fetch(step.to_sym) do
-            fail "No form object defined for step #{step}"
+            raise "No form object defined for step #{step}"
           end
           klass.factory(enrollment)
         end
 
+        # rubocop:disable Metrics/MethodLength
         # NB: use NullForm for steps with no html form.
         def form_object_class_map
           {
@@ -28,9 +29,10 @@ module FloodRiskEngine
             email_someone_else:      Steps::NullForm,
             check_your_answers:      Steps::NullForm,
             declaration:             Steps::NullForm,
-            confirmation:            Steps::NullForm,
+            confirmation:            Steps::NullForm
           }
         end
+        # rubocop:enable Metrics/MethodLength
       end
     end
   end

--- a/app/forms/flood_risk_engine/steps/null_form.rb
+++ b/app/forms/flood_risk_engine/steps/null_form.rb
@@ -16,13 +16,11 @@ module FloodRiskEngine
           true
         end
 
-        def validate(params)
+        def validate(*)
           true
         end
 
-        def enrollment_id
-          enrollment.id
-        end
+        delegate :id, to: enrollment, prefix: true
       end
 
       def self.factory(enrollment)

--- a/app/forms/flood_risk_engine/steps/null_form.rb
+++ b/app/forms/flood_risk_engine/steps/null_form.rb
@@ -20,7 +20,7 @@ module FloodRiskEngine
           true
         end
 
-        delegate :id, to: enrollment, prefix: true
+        delegate :id, to: :enrollment, prefix: true
       end
 
       def self.factory(enrollment)

--- a/app/models/flood_risk_engine/enrollment.rb
+++ b/app/models/flood_risk_engine/enrollment.rb
@@ -9,9 +9,11 @@ module FloodRiskEngine
     belongs_to :organisation
     belongs_to :site_address, class_name: "Address"
 
-    has_many :enrollment_exemptions, foreign_key: :enrollment_id,
+    has_many :enrollment_exemptions,
+             foreign_key: :enrollment_id,
              dependent: :restrict_with_exception
-    has_many :exemptions, through: :enrollment_exemptions,
+    has_many :exemptions,
+             through: :enrollment_exemptions,
              dependent: :restrict_with_exception
 
     serialize :step_history, Array
@@ -43,6 +45,7 @@ module FloodRiskEngine
     )
 
     private
+
     def preserve_current_step
       self.step = current_step
     end

--- a/app/models/flood_risk_engine/exemption.rb
+++ b/app/models/flood_risk_engine/exemption.rb
@@ -2,7 +2,8 @@ module FloodRiskEngine
   class Exemption < ActiveRecord::Base
     has_many :enrollment_exemptions,
              dependent: :restrict_with_exception
-    has_many :enrollments, through: :enrollment_exemptions,
+    has_many :enrollments,
+             through: :enrollment_exemptions,
              dependent: :restrict_with_exception
 
     enum category: {

--- a/app/state_machines/flood_risk_engine/enrollment_state_machine.rb
+++ b/app/state_machines/flood_risk_engine/enrollment_state_machine.rb
@@ -1,14 +1,14 @@
 module FloodRiskEngine
-# State machine using FiniteMachine
-#
-# This class defines the methods that are used to trigger a transition
-# from one state to another. There are some restrictions as to how much
-# this object can be modified. For example, instance methods are ignored
-# within definitions. Therefore, additional methods that cannot be easily
-# added to this object, are instead defined in the wrapper StepMachine.
-#
-# See finite_machine README for usage information:
-#   https://github.com/piotrmurach/finite_machine
+  # State machine using FiniteMachine
+  #
+  # This class defines the methods that are used to trigger a transition
+  # from one state to another. There are some restrictions as to how much
+  # this object can be modified. For example, instance methods are ignored
+  # within definitions. Therefore, additional methods that cannot be easily
+  # added to this object, are instead defined in the wrapper StepMachine.
+  #
+  # See finite_machine README for usage information:
+  #   https://github.com/piotrmurach/finite_machine
   require "finite_machine"
   class EnrollmentStateMachine < FiniteMachine::Definition
     initial :check_location

--- a/app/state_machines/flood_risk_engine/step_machine.rb
+++ b/app/state_machines/flood_risk_engine/step_machine.rb
@@ -10,8 +10,8 @@ module FloodRiskEngine
   class StepMachine
     attr_reader :target, :state_machine_class, :initiating_step
     def initialize(target:,
-                    state_machine_class:,
-                    step: nil)
+                   state_machine_class:,
+                   step: nil)
       @target = target
       @state_machine_class = state_machine_class
       @initiating_step = step
@@ -21,15 +21,17 @@ module FloodRiskEngine
       state.to_s
     end
 
+    # TODO: rename this method to something better. Style guide recommends
+    # not using set_ at start of method
+    # rubocop:disable Style/AccessorMethodName
     def set_step_as(step)
       restore!(step.to_sym)
     end
+    # rubocop:enable Style/AccessorMethodName
 
     def rollback_to(step)
       current = current_step
-      while current_step != step do
-        go_back! step
-      end
+      go_back!(step) while current_step != step
     rescue FiniteMachine::InvalidStateError
       set_step_as current
       raise StateMachineError, "Unable to rollback to #{step}"
@@ -93,6 +95,7 @@ module FloodRiskEngine
     )
 
     private
+
     def initiate_state_machine
       state_machine = state_machine_class.new
       state_machine.target(target)

--- a/app/state_machines/flood_risk_engine/work_flow.rb
+++ b/app/state_machines/flood_risk_engine/work_flow.rb
@@ -6,7 +6,7 @@ module FloodRiskEngine
   class WorkFlow
     # Define each work flow within Definitions
     module Definitions
-      extend self
+      module_function
 
       def local_authority
         start + local_authority_branch + finish

--- a/flood_risk_engine.gemspec
+++ b/flood_risk_engine.gemspec
@@ -1,4 +1,4 @@
-$:.push File.expand_path("../lib", __FILE__)
+$LOAD_PATH.push File.expand_path("../lib", __FILE__)
 
 # Maintain your gem's version:
 require "flood_risk_engine/version"

--- a/lib/flood_risk_engine/engine.rb
+++ b/lib/flood_risk_engine/engine.rb
@@ -30,7 +30,7 @@ module FloodRiskEngine
     end
 
     # Make Engine Factories available to Apps
-    unless(Rails.env.production?)
+    unless Rails.env.production?
       initializer "flood_risk_engine.factories", after: "factory_girl.set_factory_paths" do
         require "factory_girl"
 

--- a/spec/controllers/flood_risk_engine/enrollments/steps_controller_spec.rb
+++ b/spec/controllers/flood_risk_engine/enrollments/steps_controller_spec.rb
@@ -28,7 +28,7 @@ module FloodRiskEngine
         end
 
         describe "back step (step == (enrollment.step - 1)" do
-          let(:step) {steps[0]}
+          let(:step) { steps[0] }
           let(:enrollment) { FactoryGirl.create(:enrollment, step: steps[1]) }
           it "should render page successfully" do
             expect(response).to have_http_status(:success)
@@ -40,7 +40,7 @@ module FloodRiskEngine
 
         context "mismatches" do
           describe "large (step many steps from enrollment.step)" do
-            let(:step) {steps.first}
+            let(:step) { steps.first }
             let(:enrollment) { FactoryGirl.create(:enrollment, step: steps.last) }
             it "should redirect to enrollment.step" do
               expect(response).to redirect_to(
@@ -50,7 +50,7 @@ module FloodRiskEngine
           end
 
           describe "step too soon (step one after enrollment.step)" do
-            let(:step) {steps[2]}
+            let(:step) { steps[2] }
             let(:enrollment) { FactoryGirl.create(:enrollment, step: steps[1]) }
             it "should redirect to enrollment.step" do
               expect(response).to redirect_to(

--- a/spec/forms/flood_risk_engine/user_type_form_spec.rb
+++ b/spec/forms/flood_risk_engine/user_type_form_spec.rb
@@ -18,7 +18,7 @@ module FloodRiskEngine
     describe "#save" do
       it "saves the enrollment.organisation with the correct STI type" do
         sti_type = FloodRiskEngine::OrganisationTypes::Individual
-        params = { params_key => { type: sti_type.to_s }}
+        params = { params_key => { type: sti_type.to_s } }
 
         expect(enrollment).to receive(:save).and_return(true) # stub save
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,8 +34,8 @@ ActiveRecord::Migration.maintain_test_schema!
 Faker::Config.locale = "en-GB"
 
 # FactoryGirl willl not find the factories without the line below
-#FactoryGirl.definition_file_paths << File.join(File.dirname(__FILE__), "factories")
-#FactoryGirl.find_definitions
+# FactoryGirl.definition_file_paths << File.join(File.dirname(__FILE__), "factories")
+# FactoryGirl.find_definitions
 
 RSpec.configure do |config|
   # Allows us to include should matchers like validate_presence_of if the spec type

--- a/spec/state_machines/flood_risk_engine/step_machine_spec.rb
+++ b/spec/state_machines/flood_risk_engine/step_machine_spec.rb
@@ -29,7 +29,7 @@ module FloodRiskEngine
     end
 
     describe ".go_back" do
-      before {step_machine.restore! steps.last.to_sym}
+      before { step_machine.restore! steps.last.to_sym }
       it "should change current step to previous step" do
         expect(step_machine.current_step).to eq(steps[2])
         step_machine.go_back!

--- a/spec/state_machines/flood_risk_engine/work_flow_spec.rb
+++ b/spec/state_machines/flood_risk_engine/work_flow_spec.rb
@@ -3,9 +3,9 @@ require "rails_helper"
 module FloodRiskEngine
   describe WorkFlow do
     let(:work_flow) { WorkFlow.new(:start) }
-    let(:start_hash) { work_flow.make_hash(work_flow.work_flow)}
+    let(:start_hash) { work_flow.make_hash(work_flow.work_flow) }
     let(:array) { [:a, :b, :c, :d] }
-    let(:hash) { {a: :b, b: :c, c: :d } }
+    let(:hash) { { a: :b, b: :c, c: :d } }
 
     describe ".make_hash" do
       it "should convert an array into a hash" do

--- a/spec/support/page_objects/flood_risk_engine/steps/new_structure_page.rb
+++ b/spec/support/page_objects/flood_risk_engine/steps/new_structure_page.rb
@@ -18,10 +18,9 @@ module FloodRisk
         end
 
         def submit
-          fail "Not impl yet"
+          raise "Not impl yet"
         end
 
-        private
       end
     end
   end

--- a/spec/support/state_machines/test_state_machine.rb
+++ b/spec/support/state_machines/test_state_machine.rb
@@ -6,7 +6,7 @@ module FloodRiskEngine
     initial :step1
 
     module WorkFlow
-      extend self
+      module_function
 
       def steps
         [:step1, :step2, :step3]
@@ -28,24 +28,24 @@ module FloodRiskEngine
 
     events do
       event :go_forward,
-        WorkFlow.foo.merge(
-          if: -> { target.business_type == :foo }
-        )
+            WorkFlow.foo.merge(
+              if: -> { target.business_type == :foo }
+            )
 
       event :go_forward,
-        WorkFlow.bar.merge(
-          if: -> { target.business_type == :bar }
-        )
+            WorkFlow.bar.merge(
+              if: -> { target.business_type == :bar }
+            )
 
       event :go_back,
-        WorkFlow.foo.invert.merge(
-          if: -> { target.business_type == :foo }
-        )
+            WorkFlow.foo.invert.merge(
+              if: -> { target.business_type == :foo }
+            )
 
       event :go_back,
-        WorkFlow.bar.invert.merge(
-          if: -> { target.business_type == :bar }
-        )
+            WorkFlow.bar.invert.merge(
+              if: -> { target.business_type == :bar }
+            )
     end
   end
 end


### PR DESCRIPTION
rubocop rules defined via before_commit 0.6.1 have caused tens of failure. These failures are reconciled here.