### PR TITLE
Add integration to travis-ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-/.htmlhintrc
 /.byebug_history
 .bundle/
 log/*.log

--- a/.htmlhintrc
+++ b/.htmlhintrc
@@ -1,0 +1,22 @@
+{
+  "tagname-lowercase": true,
+  "attr-lowercase": true,
+  "attr-value-double-quotes": true,
+  "attr-value-not-empty": false,
+  "attr-no-duplication": true,
+  "doctype-first": false,
+  "tag-pair": true,
+  "tag-self-close": true,
+  "spec-char-escape": false,
+  "id-unique": true,
+  "src-not-empty": true,
+  "head-script-disabled": false,
+  "img-alt-require": true,
+  "doctype-html5": true,
+  "id-class-value": false,
+  "style-disabled": false,
+  "space-tab-mixed-disabled": false,
+  "id-class-ad-disabled": false,
+  "href-abs-or-rel": false,
+  "attr-unsafe-chars": false
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+language: ruby
+cache: bundler
+
+rvm:
+  - 2.2.3
+
+addons:
+  postgresql: "9.4"
+
+
+# We need nodejs version >= 4 to be compatible with htmlhint >= 0.9.13
+# This overwrites the system node  0.10.x
+before_install:
+  - nvm install node
+
+env:
+  - DB=pg
+
+bundler_args: --binstubs=./bundler_stubs
+
+before_script:
+  - npm install -g jshint coffeelint htmlhint csslint # overcommit packages
+
+script:
+  - bundle exec rake --trace before_commit:run_without_checks
+  - htmlhint -c ./.htmlhintrc ./app/**/*.html.erb
+  - git config --global user.email test@example.com # overcommit Author
+  - git config --global user.name "Test Example" # overcommit Author
+  - BUNDLE_GEMFILE=.overcommit_gems.rb bundle exec overcommit --run
+  - RAILS_ENV=test bundle exec rake db:migrate --trace
+  - bundle exec rspec
+
+# Have this option to stop travis-ci building twice. Currently we have travis set to build both
+# PR's and pushes. However this means when we push to a PR we have to wait for Travis to finish
+# 2 builds. If we unticked 'pushes' when the PR was finally merged that would not be built. The
+# brute force approach would be to untick build PR's and just build all pushes. We instead have
+# gone with the approach outlined here http://stackoverflow.com/a/31882307
+branches:
+  only:
+    - master
+    - develop

--- a/Gemfile
+++ b/Gemfile
@@ -16,4 +16,5 @@ group :test do
   gem "guard-rspec", require: false
   gem "rspec-html-matchers"
   gem "database_cleaner", "~> 1.5"
+  gem "codeclimate-test-reporter", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     flood_risk_engine (0.0.1)
-      dibber (~> 0.5)
+      dibber (~> 0.4)
       dotenv-rails (~> 2.1)
       finite_machine (~> 0.10)
       jquery-rails (~> 4.1)
@@ -53,12 +53,12 @@ GEM
     ast (2.2.0)
     autoprefixer-rails (6.3.6)
       execjs
-    before_commit (0.7.0)
+    before_commit (0.8.0)
     bootstrap-sass (3.3.6)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
     builder (3.2.2)
-    byebug (8.2.4)
+    byebug (8.2.5)
     capybara (2.7.0)
       addressable
       mime-types (>= 1.16)
@@ -67,6 +67,8 @@ GEM
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
     cliver (0.3.2)
+    codeclimate-test-reporter (0.5.0)
+      simplecov (>= 0.7.1, < 1.0.0)
     coderay (1.1.1)
     concurrent-ruby (1.0.1)
     database_cleaner (1.5.3)
@@ -138,7 +140,7 @@ GEM
     notiffany (0.0.8)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    parser (2.3.0.7)
+    parser (2.3.1.0)
       ast (~> 2.2)
     poltergeist (1.9.0)
       capybara (~> 2.1)
@@ -264,10 +266,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  before_commit (~> 0.2)
+  before_commit (~> 0.6)
   bootstrap-sass (~> 3.3)
   byebug (~> 8.2)
   capybara (~> 2.6)
+  codeclimate-test-reporter
   database_cleaner (~> 1.5)
   factory_girl_rails (~> 4.6)
   faker

--- a/README.md
+++ b/README.md
@@ -1,30 +1,24 @@
-FloodRiskEngine
-===============
+# FloodRiskEngine
 
+[![Build Status](https://travis-ci.org/EnvironmentAgency/flood-risk-engine.svg?branch=develop)](https://travis-ci.org/EnvironmentAgency/flood-risk-engine)
 
-Development
------------
+## Development
 
-Before making changes for the first time, please run the
-before_commit rake task to install `overcommit` and the
-associated tasks
+Before making changes for the first time, please run the before_commit rake task to install `overcommit` and the associated tasks
 
 ```bash
 rake app:before_commit:run
 ```
 
-And use before_commit to keep the overcommit configuration
-up to date.
+And use before_commit to keep the overcommit configuration up to date.
 
-Contributing to this project
-----------------------------
+## Contributing to this project
 
 If you have an idea you'd like to contribute please log an issue.
 
 All contributions should be submitted via a pull request.
 
-License
--------
+## License
 
 THIS INFORMATION IS LICENSED UNDER THE CONDITIONS OF THE OPEN GOVERNMENT LICENCE found at:
 

--- a/app/views/flood_risk_engine/enrollments/steps/_check_exemptions.html.erb
+++ b/app/views/flood_risk_engine/enrollments/steps/_check_exemptions.html.erb
@@ -1,4 +1,5 @@
-<table class="check-your-answers" summary="<%= t("flood_risk_engine.enrollments.steps.check_exemptions.table_summary") %>">
+<table class="check-your-answers"
+      summary="<%= t('flood_risk_engine.enrollments.steps.check_exemptions.table_summary') %>">
   <tbody>
     <% form.enrollment.exemptions.each do |exemption| %>
     <tr>

--- a/app/views/flood_risk_engine/enrollments/steps/_check_location.html.erb
+++ b/app/views/flood_risk_engine/enrollments/steps/_check_location.html.erb
@@ -8,7 +8,9 @@
       <li><%= t('.list_item2') %></li>
     </ul>
   </div>
-  <br>
+
+  <br/>
+
   <%= form_group_and_validation(form, :location_check) do %>
     <div class="form-group">
 

--- a/app/views/pages/contact_ea_location.html.erb
+++ b/app/views/pages/contact_ea_location.html.erb
@@ -14,7 +14,7 @@
     <div class="contact">
       <h3 class="heading-medium">Contact the Environment Agency</h3>
       <%= link_to 'enquiries@environment-agency.gov.uk', 'mailto:enquiries@environment-agency.gov.uk_url' %>
-      <br><%= t('.div_text11') %><br><%= t('.div_text12') %><br><%= t('.div_text13') %>
+      <br/><%= t('.div_text11') %><br/><%= t('.div_text12') %><br/><%= t('.div_text13') %>
     </div>
 
   </div>

--- a/config/locales/flood_risk_engine/_local_authority.en.yml
+++ b/config/locales/flood_risk_engine/_local_authority.en.yml
@@ -3,7 +3,7 @@ en:
   flood_risk_engine:
     enrollments:
       steps:
-        local_authority: 
+        local_authority:
           heading: What's the name of the local authority or public body?
           label: Local authority or public body name
           legend: Local authority or public body name

--- a/db/migrate/20160503152619_recreate_exemptions_code_number_index.rb
+++ b/db/migrate/20160503152619_recreate_exemptions_code_number_index.rb
@@ -1,0 +1,10 @@
+class RecreateExemptionsCodeNumberIndex < ActiveRecord::Migration
+  def up
+    remove_index :flood_risk_engine_exemptions, :code_number
+    add_index :flood_risk_engine_exemptions, :code_number, unique: false
+  end
+  def down
+    remove_index :flood_risk_engine_exemptions, :code_number
+    add_index :flood_risk_engine_exemptions, :code_number, unique: true
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,7 @@
-require 'dibber'
+require "dibber"
 # https://github.com/reggieb/Dibber
 Seeder = Dibber::Seeder
-Seeder.seeds_path = File.expand_path('seeds', File.dirname(__FILE__))
+Seeder.seeds_path = File.expand_path("seeds", File.dirname(__FILE__))
 
 # Note that if an Exemptions exists seeding will just update the summary
 Seeder.seed(
@@ -11,6 +11,4 @@ Seeder.seed(
   overwrite: true
 )
 
-puts Seeder.report
-
-
+Rails.logger.info Seeder.report

--- a/flood_risk_engine.gemspec
+++ b/flood_risk_engine.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency "jquery-rails", "~> 4.1"
 
   s.add_development_dependency "sqlite3", "~> 1.3"
-  s.add_development_dependency "before_commit", "~> 0.2"
+  s.add_development_dependency "before_commit", "~> 0.6"
   s.add_development_dependency "rubocop"
   s.add_development_dependency "bootstrap-sass", "~> 3.3"
   s.add_development_dependency "sass-rails", ">= 3.2"

--- a/spec/controllers/flood_risk_engine/enrollments/local_authority_spec.rb
+++ b/spec/controllers/flood_risk_engine/enrollments/local_authority_spec.rb
@@ -25,7 +25,6 @@ module FloodRiskEngine
       end
 
       context "with invalid params" do
-
         let(:invalid_attributes) {
           { name: "12345 not a valid name **" }
         }
@@ -50,9 +49,7 @@ module FloodRiskEngine
           pending "response says you are being redirected - not sure how to test validations in these tests"
           expect(response.body).to have_tag :a, text: expected_error
         end
-
       end
-
     end
   end
 end

--- a/spec/dummy/app/views/not_in_engines/_form.html.erb
+++ b/spec/dummy/app/views/not_in_engines/_form.html.erb
@@ -12,7 +12,7 @@
   <% end %>
 
   <div class="field">
-    <%= f.label :name %><br>
+    <%= f.label :name %><br/>
     <%= f.text_field :name %>
   </div>
   <div class="actions">

--- a/spec/dummy/app/views/not_in_engines/index.html.erb
+++ b/spec/dummy/app/views/not_in_engines/index.html.erb
@@ -22,6 +22,6 @@
   </tbody>
 </table>
 
-<br>
+<br/>
 
 <%= link_to 'New Not in engine', new_not_in_engine_path %>

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160503133237) do
+ActiveRecord::Schema.define(version: 20160503152619) do
 
   create_table "flood_risk_engine_addresses", force: :cascade do |t|
     t.string   "premises",            limit: 200
@@ -82,7 +82,7 @@ ActiveRecord::Schema.define(version: 20160503133237) do
     t.integer  "code_number"
   end
 
-  add_index "flood_risk_engine_exemptions", ["code_number"], name: "index_flood_risk_engine_exemptions_on_code_number", unique: true
+  add_index "flood_risk_engine_exemptions", ["code_number"], name: "index_flood_risk_engine_exemptions_on_code_number"
 
   create_table "flood_risk_engine_locations", force: :cascade do |t|
     t.integer  "address_id"

--- a/spec/forms/flood_risk_engine/local_authority_form_spec.rb
+++ b/spec/forms/flood_risk_engine/local_authority_form_spec.rb
@@ -39,14 +39,16 @@ module FloodRiskEngine
           params = { "#{form.params_key}": { name: "" } }
 
           expect(form.validate(params)).to eq false
-          expect(subject.errors.messages[:name]).to eq([I18n.t("#{LocalAuthorityForm.locale_key}.errors.name.blank")])
+          expect(subject.errors.messages[:name])
+            .to eq([I18n.t("#{LocalAuthorityForm.locale_key}.errors.name.blank")])
         end
 
         it "does not validate when name with unacceptable chars" do
           params = { "#{form.params_key}": { name: "bristol *& " } }
 
           expect(form.validate(params)).to eq false
-          expect(subject.errors.messages[:name]).to eq([I18n.t("flood_risk_engine.validation_errors.name.invalid")])
+          expect(subject.errors.messages[:name])
+            .to eq([I18n.t("flood_risk_engine.validation_errors.name.invalid")])
         end
 
         it "does not validate when name supplied is too long" do
@@ -54,9 +56,9 @@ module FloodRiskEngine
           params = { "#{form.params_key}": { name: name } }
 
           expect(form.validate(params)).to eq false
-          expect(subject.errors.messages[:name]).to eq([I18n.t("#{LocalAuthorityForm.locale_key}.errors.name.too_long")])
+          expect(subject.errors.messages[:name])
+            .to eq([I18n.t("#{LocalAuthorityForm.locale_key}.errors.name.too_long")])
         end
-
       end
     end
   end


### PR DESCRIPTION
_This is the re-creation of  #21 to simplify merging_

We believe its important to build CI into your development process, and use [Travis-CI](https://travis-ci.org/) for our open source projects as its free, flexible and simple to use.

This change adds everything required to integrate the project with Travis-CI, and get it automatically building our PR's and branches. It includes

- addition of a `.travis.yml` build config file
- adding a badge to `README.md` to display the current build status of the project