### PR TITLE
Ensure errors are rendered via a redirect to show.

### DIFF
--- a/app/controllers/flood_risk_engine/enrollments/steps_controller.rb
+++ b/app/controllers/flood_risk_engine/enrollments/steps_controller.rb
@@ -15,6 +15,7 @@ module FloodRiskEngine
       before_action :back_button_cache_buster
 
       def show
+        form.valid? if params[:check_for_error]
         render :show, locals: locals
       end
 
@@ -26,7 +27,8 @@ module FloodRiskEngine
         elsif success
           redirect_to step_url
         else
-          render :show, locals: locals
+          enrollment.go_back
+          redirect_to failure_url
         end
       end
 
@@ -36,8 +38,15 @@ module FloodRiskEngine
         @step ||= params.fetch(:id).to_sym
       end
 
-      def step_url
-        enrollment_step_path(enrollment, enrollment.current_step)
+      def step_url(extra = {})
+        enrollment_step_path(enrollment, enrollment.current_step, extra)
+      end
+
+      def failure_url
+        step_url(
+          form.params_key => params[form.params_key],
+          check_for_error: true
+        )
       end
 
       def check_step_is_valid

--- a/spec/controllers/flood_risk_engine/enrollments/steps_controller/steps_controller_show_spec.rb
+++ b/spec/controllers/flood_risk_engine/enrollments/steps_controller/steps_controller_show_spec.rb
@@ -13,7 +13,7 @@ module FloodRiskEngine
         end
       end
 
-      context "edit action" do
+      context "show action" do
         before do
           get :show, id: step, enrollment_id: enrollment
         end
@@ -56,6 +56,20 @@ module FloodRiskEngine
               )
             end
           end
+        end
+      end
+
+      context "show with test_for_errors" do
+        let(:step) { steps[1] }
+        before do
+          expect_any_instance_of(Steps::BaseForm).to(
+            receive(:valid?).and_return(false)
+          )
+          get :show, id: step, enrollment_id: enrollment, check_for_error: true
+        end
+
+        it "should render page successfully" do
+          expect(response).to have_http_status(:success)
         end
       end
     end

--- a/spec/controllers/flood_risk_engine/enrollments/steps_controller/steps_controller_update_spec.rb
+++ b/spec/controllers/flood_risk_engine/enrollments/steps_controller/steps_controller_update_spec.rb
@@ -34,8 +34,10 @@ module FloodRiskEngine
       context "failure" do
         let(:validation_result) { false }
 
-        it "should stay on the current step" do
-          expect(response).to have_http_status(:success)
+        it "should redirect back to current step with check for errors" do
+          expect(response).to redirect_to(
+            enrollment_step_path(enrollment, step, check_for_error: true)
+          )
         end
       end
     end


### PR DESCRIPTION
Fix to issue https://github.com/EnvironmentAgency/flood-risk-engine/issues/38

It changes the update step action so that it redirects to show with the params that generated the error.