### PR TITLE
Change show to use form method `validate` when checking for errors.

### DIFF
--- a/app/controllers/flood_risk_engine/enrollments/steps_controller.rb
+++ b/app/controllers/flood_risk_engine/enrollments/steps_controller.rb
@@ -15,7 +15,7 @@ module FloodRiskEngine
       before_action :back_button_cache_buster
 
       def show
-        form.valid? if params[:check_for_error]
+        form.validate(params) if params[:check_for_error]
         render :show, locals: locals
       end
 

--- a/app/factories/flood_risk_engine/steps/form_object_factory.rb
+++ b/app/factories/flood_risk_engine/steps/form_object_factory.rb
@@ -3,7 +3,6 @@ module FloodRiskEngine
     class FormObjectFactory
       class << self
         def form_object_for(step, enrollment)
-
           klass = form_object_class_map[step.to_sym] || setup_form_object(step)
 
           raise(FormObjectError, "No form object defined for step #{step}") unless klass

--- a/app/validators/flood_risk_engine/name_format_validator.rb
+++ b/app/validators/flood_risk_engine/name_format_validator.rb
@@ -5,8 +5,8 @@ module FloodRiskEngine
   class NameFormatValidator < ActiveModel::EachValidator
 
     def validate_each(record, attribute, value)
-      if(value !~ NameFormatValidator.valid_name_regex)
-        record.errors.add attribute,  I18n.t("flood_risk_engine.validation_errors.name.invalid")
+      if value !~ NameFormatValidator.valid_name_regex
+        record.errors.add attribute, I18n.t("flood_risk_engine.validation_errors.name.invalid")
       end
     end
 

--- a/spec/controllers/flood_risk_engine/enrollments/local_authority_spec.rb
+++ b/spec/controllers/flood_risk_engine/enrollments/local_authority_spec.rb
@@ -22,6 +22,5 @@ module FloodRiskEngine
         expect(response.body).to have_tag :h1, text: /#{header_text}/
       end
     end
-
   end
 end

--- a/spec/factories/page_related_enrollments_factory.rb
+++ b/spec/factories/page_related_enrollments_factory.rb
@@ -1,12 +1,10 @@
 # A suite of Enrollments that enable you to jump straight to a particular page in the jounrey
 
 FactoryGirl.define do
-
   factory :page_check_location, class: FloodRiskEngine::Enrollment do
   end
 
   factory :page_local_authority, class: FloodRiskEngine::Enrollment do
     step :local_authority
   end
-
 end

--- a/spec/forms/flood_risk_engine/local_authority_form_spec.rb
+++ b/spec/forms/flood_risk_engine/local_authority_form_spec.rb
@@ -40,8 +40,6 @@ module FloodRiskEngine
 
           expect(form.validate(params)).to eq false
         end
-
-
       end
     end
   end

--- a/spec/lib/flood_risk_engine/form_object_factory_spec.rb
+++ b/spec/lib/flood_risk_engine/form_object_factory_spec.rb
@@ -2,12 +2,11 @@ require "rails_helper"
 
 module FloodRiskEngine
   describe Steps::FormObjectFactory do
-
     let!(:factory) { Steps::FormObjectFactory }
 
     let!(:enrollment) { Enrollment.new }
 
-    it 'anables us to find the FormObject for a defined Step' do
+    it "anables us to find the FormObject for a defined Step" do
       expect(factory).to respond_to(:form_object_for)
     end
 
@@ -16,11 +15,11 @@ module FloodRiskEngine
     end
 
     it "returns a form Object for a valid step", duff: true do
-      expect( factory.form_object_for(Enrollment.new.current_step.to_sym, enrollment) ).to be_a Steps::BaseForm
+      expect(factory.form_object_for(Enrollment.new.current_step.to_sym, enrollment)).to be_a Steps::BaseForm
     end
 
     it "returns a form Object for a valid step" do
-      expect( factory.form_object_for(Enrollment.new.current_step.to_s, enrollment) ).to be_a Steps::BaseForm
+      expect(factory.form_object_for(Enrollment.new.current_step.to_s, enrollment)).to be_a Steps::BaseForm
     end
   end
 end

--- a/spec/validators/name_format_validator_spec.rb
+++ b/spec/validators/name_format_validator_spec.rb
@@ -2,19 +2,18 @@ require "rails_helper"
 
 module FloodRiskEngine
   RSpec.describe NameFormatValidator, type: :model do
-
     class Validatable
       include ActiveModel::Validations
 
       validates :name, "flood_risk_engine/name_format": true
 
-      attr_accessor  :name
+      attr_accessor :name
     end
 
     let(:validatable) { Validatable.new }
 
-    context 'with valid name' do
-      it 'is valid' do
+    context "with valid name" do
+      it "is valid" do
         validatable.name = Faker::Company.name
 
         expect(validatable.valid?).to be true
@@ -34,16 +33,15 @@ module FloodRiskEngine
     end
 
     describe "Invalid" do
-
-      context 'without name' do
-        it 'is invalid' do
+      context "without name" do
+        it "is invalid" do
           expect(validatable.valid?).to be_falsey
           expect(validatable.errors[:name].size).to eq(1)
         end
       end
 
-      context 'with invalid charcters' do
-        it 'is invalid' do
+      context "with invalid charcters" do
+        it "is invalid" do
           validatable.name = Faker::Company.name + " 12 * &"
 
           expect(validatable.valid?).to be_falsey
@@ -53,4 +51,3 @@ module FloodRiskEngine
     end
   end
 end
-


### PR DESCRIPTION
Calling form.valid? does not work in the way I thought. Need to pass the params to the form via the `validate` method to get the form to register the errors correctly.