### PR TITLE
Set default scope for Exemptions so that they sort by code

### DIFF
--- a/app/models/flood_risk_engine/exemption.rb
+++ b/app/models/flood_risk_engine/exemption.rb
@@ -1,5 +1,7 @@
 module FloodRiskEngine
   class Exemption < ActiveRecord::Base
+    default_scope { order("CAST(#{table_name}.code AS int)") }
+
     has_many :enrollment_exemptions,
              dependent: :restrict_with_exception
     has_many :enrollments,

--- a/db/seeds/flood_risk_engine/exemptions.yml
+++ b/db/seeds/flood_risk_engine/exemptions.yml
@@ -20,8 +20,6 @@ FRA19: Constructing eel pass devices on existing structures
 FRA20: Constructing fish passage notches in an existing impounding structure
 FRA21: Removing silt and sand from bridge arches and any material from existing culverts
 FRA22: Removing silt and sand adjacent to in-river structures
-FRA23: Dredging to remove accumulated silt and sand from the bed of up to 1.5km of manmade ditches, land drains, agricultural drains and previously straightened watercourses that are main rivers
-FRA24: Dredging to remove accumulated silt and sand from the bed of up to 20 metres of a main river
 FRA25: Excavating scrapes and shallow wetland features totalling 0.1 hectare in a flood plain
 FRA26: Constructing raised flood defences around a maximum of 6 adjoining properties
 FRA27: Constructing bankside wildlife refuge structures


### PR DESCRIPTION
The sorting should only use the numeric part of the code.

Also remove erroneous Exemptions from seeds.