### PR TITLE
Change exemption ordering to use an integer field

### DIFF
--- a/app/models/flood_risk_engine/exemption.rb
+++ b/app/models/flood_risk_engine/exemption.rb
@@ -1,6 +1,6 @@
 module FloodRiskEngine
   class Exemption < ActiveRecord::Base
-    default_scope { order("CAST(#{table_name}.code AS int)") }
+    default_scope { order(:code_number) }
 
     has_many :enrollment_exemptions,
              dependent: :restrict_with_exception
@@ -11,9 +11,17 @@ module FloodRiskEngine
     enum category: {
     }
 
+    before_save :update_code_number
+
     # An exemption's friendly name, used for example when listing exemptions in an email.
     def to_s
       "#{code}: #{summary}"
+    end
+
+    private
+
+    def update_code_number
+      self.code_number = code.gsub(/\D/, "").to_i
     end
   end
 end

--- a/db/migrate/20160503133237_add_code_number_to_flood_risk_engine_exemptions.rb
+++ b/db/migrate/20160503133237_add_code_number_to_flood_risk_engine_exemptions.rb
@@ -1,0 +1,9 @@
+class AddCodeNumberToFloodRiskEngineExemptions < ActiveRecord::Migration
+  def change
+    add_column :flood_risk_engine_exemptions, :code_number, :integer
+
+    add_index :flood_risk_engine_exemptions, :code_number, unique: true
+
+    FloodRiskEngine::Exemption.all.each &:save
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160419132958) do
+ActiveRecord::Schema.define(version: 20160503133237) do
 
   create_table "flood_risk_engine_addresses", force: :cascade do |t|
     t.string   "premises",            limit: 200
@@ -79,7 +79,10 @@ ActiveRecord::Schema.define(version: 20160419132958) do
     t.text     "description"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.integer  "code_number"
   end
+
+  add_index "flood_risk_engine_exemptions", ["code_number"], name: "index_flood_risk_engine_exemptions_on_code_number", unique: true
 
   create_table "flood_risk_engine_locations", force: :cascade do |t|
     t.integer  "address_id"

--- a/spec/models/flood_risk_engine/exemption_spec.rb
+++ b/spec/models/flood_risk_engine/exemption_spec.rb
@@ -5,5 +5,14 @@ module FloodRiskEngine
     it { is_expected.to be_valid }
     it { is_expected.to have_many(:enrollment_exemptions).dependent(:restrict_with_exception) }
     it { is_expected.to have_many(:enrollments).through(:enrollment_exemptions) }
+
+    describe ".code_number" do
+      let(:number) { 44 }
+
+      it "should be updated on save" do
+        exemption = described_class.create(code: "foo#{number}", summary: "foo")
+        expect(exemption.code_number).to eq(number)
+      end
+    end
   end
 end


### PR DESCRIPTION
The CAST statement fails on PostgreSQL - it won't automatically pull the numeric content out of a string as other SQL flavours will. 

I thought about changing the CAST statement to a PostgreSQL version (stripping the numbers out using regex), but in the end decided to use a separate integer field as we can then index on that field easily.