### PR TITLE
Update organisation type labels via locale, to match prototype

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,12 +2,12 @@ en:
   activerecord:
     attributes:
       flood_risk_engine/organisation:
-        local_authority: Local Authority
-        individual: Individual
-        limited_company: Limited Company
-        limited_liability_partnership: Limited Liability Partnership
-        other: Other
-        unknown: Unknown
+        local_authority: Local authority or public body
+        individual: Individual (eg a householder)
+        limited_company: Limited company (eg a registered company or plc)
+        limited_liability_partnership: Limited liability partnership
+        other: Other organisation (eg a trust, charity or club)
+        unknown: I don't know
   activemodel:
     errors:
       messages:


### PR DESCRIPTION
Reviewing the results of the RIP 72 update in the front end app: the organisation name labels need to be updated.