### PR TITLE
Move error params from url to session store

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     flood_risk_engine (0.0.1)
+      activerecord-session_store (~> 0.1)
       dibber (~> 0.5)
       dotenv-rails (~> 2.1)
       finite_machine (~> 0.10)
@@ -44,6 +45,10 @@ GEM
       activemodel (= 4.2.6)
       activesupport (= 4.2.6)
       arel (~> 6.0)
+    activerecord-session_store (0.1.2)
+      actionpack (>= 4.0.0, < 5)
+      activerecord (>= 4.0.0, < 5)
+      railties (>= 4.0.0, < 5)
     activesupport (4.2.6)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
@@ -292,4 +297,4 @@ DEPENDENCIES
   simplecov (~> 0.11)
 
 BUNDLED WITH
-   1.12.1
+   1.12.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -297,4 +297,4 @@ DEPENDENCIES
   simplecov (~> 0.11)
 
 BUNDLED WITH
-   1.12.2
+   1.12.3

--- a/app/controllers/flood_risk_engine/enrollments/exemptions_controller.rb
+++ b/app/controllers/flood_risk_engine/enrollments/exemptions_controller.rb
@@ -1,32 +1,34 @@
 require_dependency "flood_risk_engine/application_controller"
 
 module FloodRiskEngine
-  class Enrollments::ExemptionsController < ApplicationController
+  module Enrollments
+    class ExemptionsController < ApplicationController
 
-    def show
-      destroy # allows exemptions to be removed when JavaScript is disabled.
+      def show
+        destroy # allows exemptions to be removed when JavaScript is disabled.
+      end
+
+      def destroy
+        enrollment.exemptions.destroy(exemption)
+        step_back if enrollment.exemptions.empty?
+        redirect_to enrollment_step_path(enrollment, enrollment.current_step)
+      end
+
+      private
+
+      def enrollment
+        @enrollment ||= Enrollment.find(params[:enrollment_id])
+      end
+
+      def exemption
+        @exemption ||= Exemption.find(params[:id])
+      end
+
+      def step_back
+        enrollment.go_back
+        enrollment.save
+      end
+
     end
-
-    def destroy
-      enrollment.exemptions.destroy(exemption)
-      step_back if enrollment.exemptions.empty?
-      redirect_to enrollment_step_path(enrollment, enrollment.current_step)
-    end
-
-    private
-
-    def enrollment
-      @enrollment ||= Enrollment.find(params[:enrollment_id])
-    end
-
-    def exemption
-      @exemption ||= Exemption.find(params[:id])
-    end
-
-    def step_back
-      enrollment.go_back
-      enrollment.save
-    end
-
   end
 end

--- a/app/controllers/flood_risk_engine/enrollments/steps_controller.rb
+++ b/app/controllers/flood_risk_engine/enrollments/steps_controller.rb
@@ -13,7 +13,6 @@ module FloodRiskEngine
       rescue_from StepError, with: :step_not_found
       before_action :check_step_is_valid
       before_action :back_button_cache_buster
-      before_action :clear_error_params, only: [:update]
 
       def show
         form.validate(session[:error_params]) if params[:check_for_error]
@@ -28,7 +27,10 @@ module FloodRiskEngine
           step_forward
           redirect_to step_url
         else
-          session[:error_params] = { form.params_key => params[form.params_key] }
+          # error_params will be the submitted form data or an empty hash if nothing submitted.
+          session[:error_params] = {
+            form.params_key => params.fetch(form.params_key, {})
+          }
           redirect_to step_url(check_for_error: true)
         end
       end
@@ -96,11 +98,6 @@ module FloodRiskEngine
       def step_not_found
         Rails.logger.info "Step Mismatch: :#{step} requested when enrollment at :#{enrollment.step}"
         redirect_to step_url
-      end
-
-      def clear_error_params
-        session.delete(:error_params)
-        true
       end
     end
   end

--- a/app/helpers/flood_risk_engine/application_helper.rb
+++ b/app/helpers/flood_risk_engine/application_helper.rb
@@ -17,9 +17,10 @@ module FloodRiskEngine
     def form_group_and_validation(form, attribute, &block)
       content = block_given? ? capture(&block) : ""
 
-      options = { id: error_link_id(attribute),
-                  role: "group",
-                  'aria-labelledby': "groupLabel"
+      options = {
+        id: error_link_id(attribute),
+        role: "group",
+        "aria-labelledby": "groupLabel"
       }
 
       if form && form.errors[attribute].any?

--- a/config/initializers/activerecord_session_store.rb
+++ b/config/initializers/activerecord_session_store.rb
@@ -1,0 +1,1 @@
+Rails.application.config.session_store :active_record_store, key: "overwrite-in-host-app"

--- a/db/migrate/20160505134721_add_sessions_table.rb
+++ b/db/migrate/20160505134721_add_sessions_table.rb
@@ -1,0 +1,12 @@
+class AddSessionsTable < ActiveRecord::Migration
+  def change
+    create_table :sessions do |t|
+      t.string :session_id, null: false
+      t.text :data
+      t.timestamps
+    end
+
+    add_index :sessions, :session_id, unique: true
+    add_index :sessions, :updated_at
+  end
+end

--- a/flood_risk_engine.gemspec
+++ b/flood_risk_engine.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency "jquery-rails", "~> 4.1"
   s.add_dependency "validates_email_format_of", "~> 1.6" # Validate e-mail addresses against RFC 2822 and RFC 3696
   s.add_dependency "phonelib", "~> 0.6" # Add telephone number validation
+  s.add_dependency "activerecord-session_store", "~> 0.1"
 
   s.add_development_dependency "pg", "~> 0.18"
   s.add_development_dependency "before_commit", "~> 0.6"

--- a/lib/flood_risk_engine/engine.rb
+++ b/lib/flood_risk_engine/engine.rb
@@ -1,5 +1,6 @@
 require "flood_risk_engine/configuration"
 require "flood_risk_engine/exceptions"
+require "activerecord/session_store"
 
 module FloodRiskEngine
   class Engine < ::Rails::Engine

--- a/spec/controllers/flood_risk_engine/enrollments/steps_controller/correspondence_contact_spec.rb
+++ b/spec/controllers/flood_risk_engine/enrollments/steps_controller/correspondence_contact_spec.rb
@@ -39,14 +39,19 @@ module FloodRiskEngine
           expect(assigns(:enrollment).step).to eq(step.to_s)
         end
 
-        it "does not update enrollment with contact name" do
+        it "redirects back to show with check for errors" do
           put(:update, id: step, enrollment_id: enrollment, step => invalid_attributes)
+          expect(response).to redirect_to(
+            enrollment_step_path(enrollment, step, check_for_error: true)
+          )
+        end
 
-          # HTML will contain something like
-          # <a class="error-text" href="#form_group_name">Enter the name of the local authority or public body</a>
+        it "displays error on rendering show" do
+          params = { id: step, enrollment_id: enrollment, check_for_error: true }
+          session = { error_params: { step => invalid_attributes } }
           expected_error = I18n.t("flood_risk_engine.validation_errors.full_name.invalid")
 
-          pending "response just says you are being redirected - feature tests would be better than these tests"
+          get(:show, params, session)
           expect(response.body).to have_tag :a, text: expected_error
         end
       end

--- a/spec/controllers/flood_risk_engine/enrollments/steps_controller/steps_controller_show_spec.rb
+++ b/spec/controllers/flood_risk_engine/enrollments/steps_controller/steps_controller_show_spec.rb
@@ -58,20 +58,6 @@ module FloodRiskEngine
           end
         end
       end
-
-      context "show with test_for_errors" do
-        let(:step) { steps[1] }
-        before do
-          expect_any_instance_of(Steps::BaseForm).to(
-            receive(:valid?).and_return(false)
-          )
-          get :show, id: step, enrollment_id: enrollment, check_for_error: true
-        end
-
-        it "should render page successfully" do
-          expect(response).to have_http_status(:success)
-        end
-      end
     end
   end
 end

--- a/spec/dummy/config/initializers/activerecord_session_store.rb
+++ b/spec/dummy/config/initializers/activerecord_session_store.rb
@@ -1,1 +1,0 @@
-Rails.application.config.session_store :active_record_store, key: "overwrite-in-host-app"

--- a/spec/dummy/config/initializers/activerecord_session_store.rb
+++ b/spec/dummy/config/initializers/activerecord_session_store.rb
@@ -1,0 +1,1 @@
+Rails.application.config.session_store :active_record_store, key: "overwrite-in-host-app"

--- a/spec/dummy/config/initializers/session_store.rb
+++ b/spec/dummy/config/initializers/session_store.rb
@@ -1,3 +1,0 @@
-# Be sure to restart your server when you modify this file.
-
-Rails.application.config.session_store :cookie_store, key: "_dummy_session"

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160503152619) do
+ActiveRecord::Schema.define(version: 20160505134721) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -117,6 +117,16 @@ ActiveRecord::Schema.define(version: 20160503152619) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
+
+  create_table "sessions", force: :cascade do |t|
+    t.string   "session_id", null: false
+    t.text     "data"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "sessions", ["session_id"], name: "index_sessions_on_session_id", unique: true, using: :btree
+  add_index "sessions", ["updated_at"], name: "index_sessions_on_updated_at", using: :btree
 
   add_foreign_key "flood_risk_engine_addresses", "flood_risk_engine_contacts", column: "contact_id"
   add_foreign_key "flood_risk_engine_contacts", "flood_risk_engine_organisations", column: "partnership_organisation_id"

--- a/spec/forms/flood_risk_engine/correspondence_contact_email_form_spec.rb
+++ b/spec/forms/flood_risk_engine/correspondence_contact_email_form_spec.rb
@@ -60,11 +60,11 @@ module FloodRiskEngine
         end
 
         it "is invalid when confirmation email does not match supplied" do
-          params = { "#{form.params_key}":
-                       {
-                         email_address: email_address,
-                         email_address_confirmation: email_address.reverse
-                       }
+          params = {
+            "#{form.params_key}": {
+              email_address: email_address,
+              email_address_confirmation: email_address.reverse
+            }
           }
 
           expect(form.validate(params)).to eq false


### PR DESCRIPTION
Store the error data in a session key rather than the redirect url, as data was exposed, and could be too long for redirect url.