### PR TITLE
Prepopulate the email confirmation field when revisting page - RIP-119

### DIFF
--- a/app/forms/flood_risk_engine/steps/correspondence_contact_email_form.rb
+++ b/app/forms/flood_risk_engine/steps/correspondence_contact_email_form.rb
@@ -48,7 +48,6 @@ module FloodRiskEngine
       # not the confirmation, so this format prevents both format & blank messages when conf = blank
       #
       validation :confirmation_matches?, if: :confirmation_present? do
-        
         # Although not specified, Rails automatically validates against a field called email_address_confirmation,
         # See
         # http://api.rubyonrails.org/classes/ActiveModel/Validations/HelperMethods.html#method-i-validates_confirmation_of

--- a/app/forms/flood_risk_engine/steps/correspondence_contact_email_form.rb
+++ b/app/forms/flood_risk_engine/steps/correspondence_contact_email_form.rb
@@ -81,7 +81,7 @@ module FloodRiskEngine
       private
 
       def any_email_field_changed?
-        (changed["email_address"] != true && changed["email_address_confirmation"] != true)
+        (changed[:email_address] != true && changed[:email_address_confirmation] != true)
       end
 
       def email_present?

--- a/app/forms/flood_risk_engine/steps/correspondence_contact_email_form.rb
+++ b/app/forms/flood_risk_engine/steps/correspondence_contact_email_form.rb
@@ -19,6 +19,8 @@ module FloodRiskEngine
       property :email_address_confirmation, virtual: true
 
       # This group manages the main email_address field, confirmation is dependent on results of this group
+      #     docs on validation groups :  http://trailblazer.to/gems/reform/validation.html
+      #
       validation :email_address_valid? do
         validates :email_address, presence: {
           message: I18n.t("#{CorrespondenceContactEmailForm.locale_key}.errors.email_address.blank")
@@ -45,8 +47,12 @@ module FloodRiskEngine
       # The helpers ; allow_blank: true, allow_nil: true  ; only seem to apply to the email_address field
       # not the confirmation, so this format prevents both format & blank messages when conf = blank
       #
-      validation :passwords_match?, if: :confirmation_present? do
-        # Although not specified, Rails automatically validates against a field called email_address_confirmation
+      validation :confirmation_matches?, if: :confirmation_present? do
+        
+        # Although not specified, Rails automatically validates against a field called email_address_confirmation,
+        # See
+        # http://api.rubyonrails.org/classes/ActiveModel/Validations/HelperMethods.html#method-i-validates_confirmation_of
+
         validates :email_address, confirmation: {
           message: I18n.t("#{CorrespondenceContactEmailForm.locale_key}.errors.email_address_confirmation.format")
         }
@@ -80,7 +86,7 @@ module FloodRiskEngine
       end
 
       def email_present?
-        (enrollment && enrollment.correspondence_contact && !enrollment.correspondence_contact.email_address.blank?)
+        (enrollment && enrollment.correspondence_contact && enrollment.correspondence_contact.email_address.present?)
       end
 
       def no_email_errors?

--- a/app/forms/flood_risk_engine/steps/correspondence_contact_email_form.rb
+++ b/app/forms/flood_risk_engine/steps/correspondence_contact_email_form.rb
@@ -45,27 +45,46 @@ module FloodRiskEngine
       # The helpers ; allow_blank: true, allow_nil: true  ; only seem to apply to the email_address field
       # not the confirmation, so this format prevents both format & blank messages when conf = blank
       #
-      validation :passwords_match, if: :confirmation_present? do
+      validation :passwords_match?, if: :confirmation_present? do
         # Although not specified, Rails automatically validates against a field called email_address_confirmation
         validates :email_address, confirmation: {
           message: I18n.t("#{CorrespondenceContactEmailForm.locale_key}.errors.email_address_confirmation.format")
         }
       end
-      #       validates :email_address_confirmation,
-      #                 presence: {
-      #                   message: validation_message_when("email_address_confirmation.blank"),
-      #                   unless: ->(form) { form.errors.any? }
-      #                 }
-      #
-      #       validates :email_address,
-      #                 confirmation: {
-      #                   message: validation_message_when("email_address_confirmation.format"),
-      #                   unless: ->(form) { form.errors.any? }
-      #                 }
+
       def save
         super
         enrollment.correspondence_contact ||= model
         enrollment.save
+      end
+
+      # Over ride the reader used in presentation to populate the confirmation field when :
+      #   User returns after successful submission - via back or review - because we don't want to force them
+      #   to re-enter and re-confirm an already saved email address.
+      #
+      # N.B This reader used by validations as well as view so care needed as to when to populate field
+      #
+      def email_address_confirmation
+        if any_email_field_changed? && email_present? && no_email_errors?
+          enrollment.correspondence_contact.email_address
+        else
+          # important to use the Reform chain if we dont need the very specific to over ride
+          super
+        end
+      end
+
+      private
+
+      def any_email_field_changed?
+        (changed["email_address"] != true && changed["email_address_confirmation"] != true)
+      end
+
+      def email_present?
+        (enrollment && enrollment.correspondence_contact && !enrollment.correspondence_contact.email_address.blank?)
+      end
+
+      def no_email_errors?
+        (errors.empty? && enrollment.errors.empty? && enrollment.correspondence_contact.errors.empty?)
       end
 
       # Force use of the factory to create instances of this class

--- a/app/views/flood_risk_engine/enrollments/steps/_correspondence_contact_email.html.erb
+++ b/app/views/flood_risk_engine/enrollments/steps/_correspondence_contact_email.html.erb
@@ -2,12 +2,12 @@
   <%= form_group_and_validation(form, :email_address) do -%>
     <%= f.label :email_address,  t('.label') , class: 'form-label' %>
     <span class="form-hint">We’ll send the registration confirmation to this address</span>
-    <%= f.text_field 'email_address', class:  'form-control' %>
+    <%= f.email_field 'email_address', class:  'form-control' %>
   <% end %>
 
   <%= form_group_and_validation(form, :email_address_confirmation) do -%>
     <%= f.label :email_address_confirmation,  t('.label1') , class: 'form-label' %>
-    <%= f.text_field 'email_address_confirmation', class:  'form-control' %>
+    <%= f.email_field 'email_address_confirmation', class:  'form-control' %>
   <% end %>
 </fieldset>
 

--- a/app/views/flood_risk_engine/enrollments/steps/_correspondence_contact_email.html.erb
+++ b/app/views/flood_risk_engine/enrollments/steps/_correspondence_contact_email.html.erb
@@ -1,7 +1,7 @@
 <fieldset>
   <%= form_group_and_validation(form, :email_address) do -%>
     <%= f.label :email_address,  t('.label') , class: 'form-label' %>
-    <span class="form-hint">We’ll send the registration confirmation to this address</span>
+    <span class="form-hint"><%= t(".form_hint") %></span>
     <%= f.email_field 'email_address', class:  'form-control' %>
   <% end %>
 

--- a/config/locales/flood_risk_engine/enrollments/steps/_correspondence_contact_email.en.yml
+++ b/config/locales/flood_risk_engine/enrollments/steps/_correspondence_contact_email.en.yml
@@ -4,6 +4,7 @@ en:
     enrollments:
       steps:
         correspondence_contact_email:
+          form_hint: "We’ll send the registration confirmation to this address"
           heading: "What’s the email address of the person we should contact?"
           label:  Email address
           hint:  "We’ll send the registration confirmation to this address"

--- a/config/locales/flood_risk_engine/enrollments/steps/_correspondence_contact_email.en.yml
+++ b/config/locales/flood_risk_engine/enrollments/steps/_correspondence_contact_email.en.yml
@@ -1,0 +1,17 @@
+---
+en:
+  flood_risk_engine:
+    enrollments:
+      steps:
+        correspondence_contact_email:
+          heading: "What’s the email address of the person we should contact?"
+          label:  Email address
+          hint:  "We’ll send the registration confirmation to this address"
+          label1: Confirm email address
+          errors:
+            email_address:
+              blank: Enter an email address
+              format: "Enter a valid email address - there’s a mistake in that one"
+            email_address_confirmation:
+              blank: Enter your email address again to confirm it
+              format: "The email addresses you’ve entered don’t match"

--- a/spec/factories/page_related_enrollments_factory.rb
+++ b/spec/factories/page_related_enrollments_factory.rb
@@ -4,12 +4,12 @@ FactoryGirl.define do
   factory :page_check_location, class: FloodRiskEngine::Enrollment do
   end
 
-  factory :page_local_authority, parent: :enrollment, traits: [:with_exemption] do
+  factory :page_local_authority, parent: :enrollment,
+                                 traits: [:with_exemption, :with_locale_authority] do
     step :local_authority
   end
 
-  factory :page_correspondence_contact_name, parent: :enrollment,
-                                             traits: [:with_exemption, :with_locale_authority] do
+  factory :page_correspondence_contact_name, parent: :page_local_authority do
     step :correspondence_contact_name
   end
 


### PR DESCRIPTION
Use the attribute reader to pre-populate the email confirmation field when a user revisits that page after having successfully submitted a valid email address previously
