### PR TITLE
QA issue - email validations misfiring when revisting page - RIP-119

### DIFF
--- a/app/controllers/flood_risk_engine/enrollments/steps_controller.rb
+++ b/app/controllers/flood_risk_engine/enrollments/steps_controller.rb
@@ -19,8 +19,7 @@ module FloodRiskEngine
         render :show, locals: locals
       end
 
-      # rubocop:disable Metrics/AbcSize
-      def update
+      def update # rubocop:disable Metrics/AbcSize
         success = save_form!
         if form.redirect?
           redirect_to(form.redirection_url)

--- a/app/controllers/flood_risk_engine/enrollments/steps_controller.rb
+++ b/app/controllers/flood_risk_engine/enrollments/steps_controller.rb
@@ -19,6 +19,7 @@ module FloodRiskEngine
         render :show, locals: locals
       end
 
+      # rubocop:disable Metrics/AbcSize
       def update
         success = save_form!
         if form.redirect?
@@ -29,7 +30,6 @@ module FloodRiskEngine
         else
           # error_params will be the submitted form data or an empty hash if nothing submitted.
           logger.error("Form save failed : [#{form.errors.messages.inspect}")
-          logger.error("Form errors : [#{form.errors.inspect}")
           session[:error_params] = {
             form.params_key => params.fetch(form.params_key, {})
           }

--- a/app/controllers/flood_risk_engine/enrollments/steps_controller.rb
+++ b/app/controllers/flood_risk_engine/enrollments/steps_controller.rb
@@ -28,6 +28,8 @@ module FloodRiskEngine
           redirect_to step_url
         else
           # error_params will be the submitted form data or an empty hash if nothing submitted.
+          logger.error("Form save failed : [#{form.errors.messages.inspect}")
+          logger.error("Form errors : [#{form.errors.inspect}")
           session[:error_params] = {
             form.params_key => params.fetch(form.params_key, {})
           }

--- a/app/forms/flood_risk_engine/steps/correspondence_contact_email_form.rb
+++ b/app/forms/flood_risk_engine/steps/correspondence_contact_email_form.rb
@@ -70,7 +70,8 @@ module FloodRiskEngine
       # N.B This reader used by validations as well as view so care needed as to when to populate field
       #
       def email_address_confirmation
-        if any_email_field_changed? && email_present? && no_email_errors?
+        if no_email_field_changed? && email_present? && no_email_errors?
+          Rails.logger.debug("Using existing email for email_address_confirmation")
           enrollment.correspondence_contact.email_address
         else
           # important to use the Reform chain if we dont need the very specific to over ride
@@ -80,8 +81,13 @@ module FloodRiskEngine
 
       private
 
+      def no_email_field_changed?
+       !any_email_field_changed?
+      end
+
       def any_email_field_changed?
-        (changed[:email_address] != true && changed[:email_address_confirmation] != true)
+        # hash is not indifferent access, use strings
+        changed.key?("email_address") || changed.key?("email_address_confirmation")
       end
 
       def email_present?

--- a/app/forms/flood_risk_engine/steps/correspondence_contact_email_form.rb
+++ b/app/forms/flood_risk_engine/steps/correspondence_contact_email_form.rb
@@ -82,7 +82,7 @@ module FloodRiskEngine
       private
 
       def no_email_field_changed?
-       !any_email_field_changed?
+        !any_email_field_changed?
       end
 
       def any_email_field_changed?

--- a/spec/forms/flood_risk_engine/correspondence_contact_email_form_spec.rb
+++ b/spec/forms/flood_risk_engine/correspondence_contact_email_form_spec.rb
@@ -38,11 +38,12 @@ module FloodRiskEngine
         end
       end
 
-      describe "Correspondence Contact Email" do
-        let(:email_address_errors)        { subject.errors.messages[:email_address] }
-        let(:email_confirmation_errors)   { subject.errors.messages[:email_address_confirmation] }
+      let(:email_address_errors)        { subject.errors.messages[:email_address] }
+      let(:email_confirmation_errors)   { subject.errors.messages[:email_address_confirmation] }
 
-        let(:locale_errors_key) { "#{CorrespondenceContactEmailForm.locale_key}.errors" }
+      let(:locale_errors_key) { "#{CorrespondenceContactEmailForm.locale_key}.errors" }
+
+      describe "Correspondence Contact Email" do
 
         it "is invalid when no email supplied" do
           params = { "#{form.params_key}": { email_address: "" } }
@@ -81,6 +82,50 @@ module FloodRiskEngine
 
             expect(email_address_errors).to eq([I18n.t("#{locale_errors_key}.email_address.format")])
           end
+        end
+      end
+      describe "Existing Correspondence Contact Email - Going Back" do
+
+        before(:each) do
+          form.enrollment.correspondence_contact.update! email_address: email_address
+
+          expect(form.enrollment.correspondence_contact.email_address).to be_present
+        end
+
+        it "is invalid  when existing email is made blank" do
+
+          params = { "#{form.params_key}": { email_address: "" } }
+
+          expect(form.validate(params)).to eq false
+
+          expect(email_address_errors).to eq([I18n.t("#{locale_errors_key}.email_address.blank")])
+        end
+
+        it "is invalid  when badly formatted email supplied" do
+          ["junk", "stilljunk@", "nope_stilljunk@.com"].each do |email|
+            form.errors.clear
+
+            params = { "#{form.params_key}": { email_address: email } }
+
+            expect(form.validate(params)).to eq false
+
+            expect(email_address_errors).to eq([I18n.t("#{locale_errors_key}.email_address.format")])
+          end
+        end
+
+        it "is invalid  when existing email is changed but not confirmed" do
+
+          # In Browser email_address_confirmation field is filled with existing
+
+          params = { "#{form.params_key}": {
+            email_address: "flood_rspec@unique.com",
+            email_address_confirmation: form.enrollment.correspondence_contact.email_address
+            }
+          }
+
+          expect(form.validate(params)).to eq false
+
+          expect(email_confirmation_errors).to eq([I18n.t("#{locale_errors_key}.email_address_confirmation.format")])
         end
       end
     end

--- a/spec/forms/flood_risk_engine/correspondence_contact_email_form_spec.rb
+++ b/spec/forms/flood_risk_engine/correspondence_contact_email_form_spec.rb
@@ -44,7 +44,6 @@ module FloodRiskEngine
       let(:locale_errors_key) { "#{CorrespondenceContactEmailForm.locale_key}.errors" }
 
       describe "Correspondence Contact Email" do
-
         it "is invalid when no email supplied" do
           params = { "#{form.params_key}": { email_address: "" } }
 
@@ -85,7 +84,6 @@ module FloodRiskEngine
         end
       end
       describe "Existing Correspondence Contact Email - Going Back" do
-
         before(:each) do
           form.enrollment.correspondence_contact.update! email_address: email_address
 
@@ -93,7 +91,6 @@ module FloodRiskEngine
         end
 
         it "is invalid  when existing email is made blank" do
-
           params = { "#{form.params_key}": { email_address: "" } }
 
           expect(form.validate(params)).to eq false
@@ -114,14 +111,12 @@ module FloodRiskEngine
         end
 
         it "is invalid  when existing email is changed but not confirmed" do
-
           # In Browser email_address_confirmation field is filled with existing
 
           params = { "#{form.params_key}": {
             email_address: "flood_rspec@unique.com",
             email_address_confirmation: form.enrollment.correspondence_contact.email_address
-            }
-          }
+          } }
 
           expect(form.validate(params)).to eq false
 


### PR DESCRIPTION
_If you go back to the page and change the second email address and then continue, it doesn't validate the two fields match (although it does if you change the first email address)
Also if you change both emails and continue it shows a validation error that the emails don't match too._

Fixed by fixing method that checks if email fields have changed in the Form