### PR TITLE
Feature/rip 57 grid reference - fix bugs found in testing

### DIFF
--- a/app/assets/javascripts/flood_risk_engine/application.js
+++ b/app/assets/javascripts/flood_risk_engine/application.js
@@ -10,4 +10,5 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
+//= details.polyfill
 //= require_tree .

--- a/app/assets/javascripts/flood_risk_engine/details.polyfill.js
+++ b/app/assets/javascripts/flood_risk_engine/details.polyfill.js
@@ -1,0 +1,207 @@
+
+// <details> polyfill
+// http://caniuse.com/#feat=details
+
+// FF Support for HTML5's <details> and <summary>
+// https://bugzilla.mozilla.org/show_bug.cgi?id=591737
+
+// http://www.sitepoint.com/fixing-the-details-element/
+
+(function () {
+
+  // Add event construct for modern browsers or IE
+  // which fires the callback with a pre-converted target reference
+  function addEvent(node, type, callback) {
+    if (node.addEventListener) {
+      node.addEventListener(type, function (e) {
+        callback(e, e.target);
+      }, false);
+    } else if (node.attachEvent) {
+      node.attachEvent('on' + type, function (e) {
+        callback(e, e.srcElement);
+      });
+    }
+  }
+
+  // Handle cross-modal click events
+  function addClickEvent(node, callback) {
+    // Prevent space(32) from scrolling the page
+    addEvent(node, 'keypress', function (e, target) {
+      if (e.keyCode === 32  && target.id.lastIndexOf("show-hide-details-summary", 0) === 0) {
+        if (e.preventDefault) {
+          e.preventDefault();
+        }
+        else { e.returnValue = false; }
+      }
+    });
+    // When the key comes up - check if it is enter(13) or space(32)
+    addEvent(node, 'keyup', function (e, target) {
+      if (e.keyCode === 13 || e.keyCode === 32) { callback(e, target); }
+    });
+    addEvent(node, 'mouseup', function (e, target) {
+      callback(e, target);
+    });
+  }
+
+  // Get the nearest ancestor element of a node that matches a given tag name
+  function getAncestor(node, match) {
+    do {
+      if (!node || node.nodeName.toLowerCase() === match) {
+        break;
+      }
+    } while (node = node.parentNode); // jshint ignore:line
+
+    return node;
+  }
+
+  // Create a started flag so we can prevent the initialisation
+  // function firing from both DOMContentLoaded and window.onload
+  var started = false;
+
+  // Initialisation function
+  function addDetailsPolyfill(list) {
+
+    // If this has already happened, just return
+    // else set the flag so it doesn't happen again
+    if (started) {
+      return;
+    }
+    started = true;
+
+    // Get the collection of details elements, but if that's empty
+    // then we don't need to bother with the rest of the scripting
+    if ((list = document.getElementsByTagName('details')).length === 0) {
+      return;
+    }
+
+    // else iterate through them to apply their initial state
+    var n = list.length, i = 0;
+    for (n; i < n; i++) {
+      var details = list[i];
+
+      // Detect native implementations
+      details.__native = typeof(details.open) == 'boolean';
+
+      // Save shortcuts to the inner summary and content elements
+      details.__summary = details.getElementsByTagName('summary').item(0);
+      details.__content = details.getElementsByTagName('div').item(0);
+
+      // If the content doesn't have an ID, assign it one now
+      // which we'll need for the summary's aria-controls assignment
+      if (!details.__content.id) {
+        details.__content.id = 'details-content-' + i;
+      }
+
+      // Add ARIA role="group" to details
+      details.setAttribute('role', 'group');
+
+      // Add role=button to summary
+      details.__summary.setAttribute('role', 'button');
+
+      // Add aria-controls
+      details.__summary.setAttribute('aria-controls', details.__content.id);
+
+      // Set tabindex so the summary is keyboard accessible
+      // details.__summary.setAttribute('tabindex', 0);
+      // http://www.saliences.com/browserBugs/tabIndex.html
+      details.__summary.tabIndex = 0;
+
+      // Detect initial open/closed state
+
+      // Native support - has 'open' attribute
+      if (details.open === true) {
+        details.__summary.setAttribute('aria-expanded', 'true');
+        details.__content.setAttribute('aria-hidden', 'false');
+        details.__content.style.display = 'block';
+      }
+
+      // Native support - doesn't have 'open' attribute
+      if (details.open === false) {
+        details.__summary.setAttribute('aria-expanded', 'false');
+        details.__content.setAttribute('aria-hidden', 'true');
+        details.__content.style.display = 'none';
+      }
+
+      var twisty;
+
+      // If this is not a native implementation
+      if (!details.__native) {
+
+        // Add an arrow
+        twisty = document.createElement('i');
+
+        // Check for the 'open' attribute
+        // If open exists, but isn't supported it won't have a value
+        if (details.getAttribute('open') === "") {
+          details.__summary.setAttribute('aria-expanded', 'true');
+          details.__content.setAttribute('aria-hidden', 'false');
+        }
+
+        // If open doesn't exist - it will be null or undefined
+        if (details.getAttribute('open') === null || details.getAttribute('open') == "undefined" ) {
+          details.__summary.setAttribute('aria-expanded', 'false');
+          details.__content.setAttribute('aria-hidden', 'true');
+          details.__content.style.display = 'none';
+        }
+
+      }
+
+      // Create a circular reference from the summary back to its
+      // parent details element, for convenience in the click handler
+      details.__summary.__details = details;
+
+      // If this is not a native implementation, create an arrow
+      // inside the summary
+      if (!details.__native) {
+
+        twisty = document.createElement('i');
+
+        if (details.getAttribute('open') === "") {
+          twisty.className = 'arrow arrow-open';
+          twisty.appendChild(document.createTextNode('\u25bc'));
+        } else {
+          twisty.className = 'arrow arrow-closed';
+          twisty.appendChild(document.createTextNode('\u25ba'));
+        }
+
+        details.__summary.__twisty = details.__summary.insertBefore(twisty, details.__summary.firstChild);
+        details.__summary.__twisty.setAttribute('aria-hidden', 'true');
+
+      }
+    }
+
+    // Define a statechange function that updates aria-expanded and style.display
+    // Also update the arrow position
+    function statechange(summary) {
+
+      var expanded = summary.__details.__summary.getAttribute('aria-expanded') == 'true';
+      var hidden = summary.__details.__content.getAttribute('aria-hidden') == 'true';
+
+      summary.__details.__summary.setAttribute('aria-expanded', (expanded ? 'false' : 'true'));
+      summary.__details.__content.setAttribute('aria-hidden', (hidden ? 'false' : 'true'));
+      summary.__details.__content.style.display = (expanded ? 'none' : 'block');
+
+      if (summary.__twisty) {
+        summary.__twisty.firstChild.nodeValue = (expanded ? '\u25ba' : '\u25bc');
+        summary.__twisty.setAttribute('class', (expanded ? 'arrow arrow-closed' : 'arrow arrow-open'));
+      }
+
+      return true;
+    }
+
+    // Bind a click event to handle summary elements
+    addClickEvent(document, function(e, summary) {
+      if (!(summary = getAncestor(summary, 'summary'))) {
+        return true;
+      }
+      return statechange(summary);
+    });
+  }
+
+  // Bind two load events for modern and older browsers
+  // If the first one fires it will set a flag to block the second one
+  // but if it's not supported then the second one will fire
+  addEvent(document, 'DOMContentLoaded', addDetailsPolyfill);
+  addEvent(window, 'load', addDetailsPolyfill);
+
+})();

--- a/app/forms/flood_risk_engine/steps/grid_reference_form.rb
+++ b/app/forms/flood_risk_engine/steps/grid_reference_form.rb
@@ -1,3 +1,4 @@
+require_relative "../../../validators/flood_risk_engine/grid_reference_validator"
 module FloodRiskEngine
   module Steps
     class GridReferenceForm < BaseForm
@@ -15,14 +16,15 @@ module FloodRiskEngine
 
       validates(
         :grid_reference,
-        format: {
-          with: /([a-zA-Z]{2})\s*(\d{3,5})\s*(\d{3,6})/,
-          message: I18n.t("#{locale_key}.errors.grid_reference.invalid"),
-          allow_blank: true
-        },
         presence: {
           message: I18n.t("#{locale_key}.errors.grid_reference.blank")
+        },
+        # using FloodRiskEngine::GridReferenceValidator
+        "flood_risk_engine/grid_reference" => {
+          message: I18n.t("#{locale_key}.errors.grid_reference.invalid"),
+          allow_blank: true
         }
+
       )
 
       def save

--- a/app/forms/flood_risk_engine/steps/grid_reference_form.rb
+++ b/app/forms/flood_risk_engine/steps/grid_reference_form.rb
@@ -24,7 +24,6 @@ module FloodRiskEngine
           message: I18n.t("#{locale_key}.errors.grid_reference.invalid"),
           allow_blank: true
         }
-
       )
 
       def save

--- a/app/validators/flood_risk_engine/grid_reference_validator.rb
+++ b/app/validators/flood_risk_engine/grid_reference_validator.rb
@@ -2,18 +2,51 @@
 module FloodRiskEngine
   class GridReferenceValidator < ActiveModel::EachValidator
 
-    def validate_each(record, attribute, value)
-      return true if allow_blank && value.blank?
-      OsMapRef::Location.for(value).easting
-    rescue OsMapRef::Error => e
-      record.errors.add attribute, (message || e.message)
-    end
-
-    attr_reader :message, :allow_blank
+    attr_reader :message, :allow_blank, :value
     def initialize(options)
       @message = options[:message]
       @allow_blank = options[:allow_blank]
       super options
+    end
+
+    def validate_each(record, attribute, value)
+      @value = value
+      return true if allow_blank && value.blank?
+      return true unless os_map_ref_detects_error? || invalid_pattern?
+      record.errors.add attribute, message
+    end
+
+    private
+
+    def os_map_ref_detects_error?
+      OsMapRef::Location.for(value).easting
+      false
+    rescue OsMapRef::Error => e
+      @message ||= e.message
+    end
+
+    # Note that OsMapRef will work with less stringent coordinates than are
+    # specified for this application - so need to add an additional check.
+    def invalid_pattern?
+      /\A#{grid_reference_pattern}\z/ !~ value.strip
+    end
+
+    def grid_reference_pattern
+      [
+        two_letters, optional_space, five_digits, optional_space, five_digits
+      ].join
+    end
+
+    def two_letters
+      "[A-Z]{2}"
+    end
+
+    def five_digits
+      '\d{5}'
+    end
+
+    def optional_space
+      '\s*'
     end
   end
 end

--- a/app/validators/flood_risk_engine/grid_reference_validator.rb
+++ b/app/validators/flood_risk_engine/grid_reference_validator.rb
@@ -1,0 +1,19 @@
+# Validate that a grid reference can be processed.
+module FloodRiskEngine
+  class GridReferenceValidator < ActiveModel::EachValidator
+
+    def validate_each(record, attribute, value)
+      return true if allow_blank && value.blank?
+      OsMapRef::Location.for(value).easting
+    rescue OsMapRef::Error => e
+      record.errors.add attribute, (message || e.message)
+    end
+
+    attr_reader :message, :allow_blank
+    def initialize(options)
+      @message = options[:message]
+      @allow_blank = options[:allow_blank]
+      super options
+    end
+  end
+end

--- a/app/views/flood_risk_engine/enrollments/steps/_grid_reference.html.erb
+++ b/app/views/flood_risk_engine/enrollments/steps/_grid_reference.html.erb
@@ -3,7 +3,7 @@
 
   <%= form_group_and_validation(form, :grid_reference) do -%>
     <div class="form-group">
-      <label class="form-label" for="grid-reference">
+      <%= f.label :grid_reference, class: "form-label" do %>
         <%= t(".form_label") %>
         <span class="form-hint">
           <%= t(".example_hint") %>
@@ -11,7 +11,7 @@
         <span class="form-hint">
           <%= t(".clarification_hint") %>
         </span>
-      </label>
+      <% end %>
       <%=
         f.text_field(
           :grid_reference,

--- a/spec/dummy/app/assets/javascripts/application.js
+++ b/spec/dummy/app/assets/javascripts/application.js
@@ -13,5 +13,6 @@
 //= require jquery
 //= require jquery_ujs
 //= require bootstrap-sprockets
+//= require flood_risk_engine/application
 //= require_tree .
 

--- a/spec/forms/flood_risk_engine/grid_reference_form_spec.rb
+++ b/spec/forms/flood_risk_engine/grid_reference_form_spec.rb
@@ -60,6 +60,20 @@ module FloodRiskEngine
           end
         end
 
+        context "with a short grid reference" do
+          before { @grid_reference = "ST 5811 7261" }
+
+          it "should return false" do
+            expect(subject.validate(params)).to eq(false)
+          end
+
+          it "should display the locale error message" do
+            subject.validate(params)
+            expect(error_message)
+              .to eq([I18n.t("#{locale_key}.errors.grid_reference.invalid")])
+          end
+        end
+
         context "with a blank grid reference" do
           before { @grid_reference = "" }
 

--- a/spec/forms/flood_risk_engine/grid_reference_form_spec.rb
+++ b/spec/forms/flood_risk_engine/grid_reference_form_spec.rb
@@ -46,6 +46,20 @@ module FloodRiskEngine
           end
         end
 
+        context "with an out of range grid reference" do
+          before { @grid_reference = "AA 58132 72695" }
+
+          it "should return false" do
+            expect(subject.validate(params)).to eq(false)
+          end
+
+          it "should display the locale error message" do
+            subject.validate(params)
+            expect(error_message)
+              .to eq([I18n.t("#{locale_key}.errors.grid_reference.invalid")])
+          end
+        end
+
         context "with a blank grid reference" do
           before { @grid_reference = "" }
 

--- a/spec/validators/grid_reference_validator_spec.rb
+++ b/spec/validators/grid_reference_validator_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe GridReferenceValidator, type: :model do
+    class Foo
+      include ActiveModel::Validations
+      attr_accessor :grid_reference, :with_message, :with_allow_blank
+      def initialize(input)
+        @grid_reference = @with_message = @with_allow_blank = input
+      end
+
+      validates(
+        :grid_reference,
+        "flood_risk_engine/grid_reference" => true
+      )
+      validates(
+        :with_message,
+        "flood_risk_engine/grid_reference" => {
+          message: "Custom"
+        }
+      )
+      validates(
+        :with_allow_blank,
+        "flood_risk_engine/grid_reference" => {
+          allow_blank: true
+        }
+      )
+    end
+    let(:grid_reference) { "ST 12345 67890" }
+    let(:foo) { Foo.new grid_reference }
+    let(:all_tested) { [:grid_reference, :with_allow_blank, :with_message] }
+
+    it "should be valid" do
+      expect(foo.valid?).to be true
+    end
+
+    context "invalid grid_reference" do
+      let(:grid_reference) { "invalid" }
+      before do
+        foo.valid?
+      end
+
+      it "should raise errors on all" do
+        expect(foo.errors.keys.sort).to eq(all_tested)
+      end
+
+      it "should have error from exception" do
+        expect(foo.errors[:grid_reference]).not_to eq(["bar"])
+        expect(foo.errors[:grid_reference].first).to be_a(String)
+      end
+
+      it "with_message should have custom message" do
+        expect(foo.errors[:with_message]).to eq(["Custom"])
+      end
+    end
+
+    context "blank grid_reference" do
+      let(:grid_reference) { "" }
+      before do
+        foo.valid?
+      end
+
+      it "should raise errors on all except with_allow_blank" do
+        expect(foo.errors.keys.sort).to eq(all_tested - [:with_allow_blank])
+      end
+    end
+  end
+end

--- a/spec/validators/grid_reference_validator_spec.rb
+++ b/spec/validators/grid_reference_validator_spec.rb
@@ -45,7 +45,7 @@ module FloodRiskEngine
       end
 
       it "should have error from exception" do
-        expect(foo.errors[:grid_reference]).not_to eq(["bar"])
+        expect(foo.errors[:grid_reference]).not_to eq(["Custom"])
         expect(foo.errors[:grid_reference].first).to be_a(String)
       end
 


### PR DESCRIPTION
Some grid references that matched the test pattern were still invalid. So now using OsMapRef errors to detect if grid reference is valid.

There was a label/input field miss-match on the page.

A polyfil was needed to give the [details tag](http://www.w3schools.com/tags/tag_details.asp) cross browser compatibility.