### PR TITLE
Remove business_type from Enrollment

### DIFF
--- a/app/models/flood_risk_engine/enrollment.rb
+++ b/app/models/flood_risk_engine/enrollment.rb
@@ -46,10 +46,6 @@ module FloodRiskEngine
       token
     end
 
-    def business_type
-      :foo
-    end
-
     def state_machine
       @state_machine ||= StepMachine.new(
         target: self,

--- a/spec/support/state_machines/test_state_machine.rb
+++ b/spec/support/state_machines/test_state_machine.rb
@@ -2,6 +2,13 @@
 # https://github.com/piotrmurach/finite_machine
 require "finite_machine"
 module FloodRiskEngine
+
+  class Enrollment
+    def business_type
+      :foo
+    end
+  end
+
   class TestStateMachine < FiniteMachine::Definition
     initial :step1
 


### PR DESCRIPTION
This is a relic from prototyping and can be safely removed.
Some state machine unit tests rely on it to excercise branching
however so it has been is monkey-patched back into Enrollment
in the the test.