### PR TITLE
Downgrade the jquery-rails gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ PATH
       finite_machine (~> 0.10)
       has_secure_token (~> 1.0.0)
       high_voltage (~> 3.0)
-      jquery-rails (~> 4.1)
+      jquery-rails (>= 3.1)
       os_map_ref (~> 0.4)
       phonelib (~> 0.6)
       rails (~> 4.2)

--- a/flood_risk_engine.gemspec
+++ b/flood_risk_engine.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "dotenv-rails", "~> 2.1"
   s.add_dependency "finite_machine", "~> 0.10"
   s.add_dependency "dibber", "~> 0.5" # Manages data seeding
-  s.add_dependency "jquery-rails", "~> 4.1"
+  s.add_dependency "jquery-rails", ">= 3.1"
   s.add_dependency "validates_email_format_of", "~> 1.6" # Validate e-mail addresses against RFC 2822 and RFC 3696
   s.add_dependency "phonelib", "~> 0.6" # Add telephone number validation
   s.add_dependency "activerecord-session_store", "~> 0.1"


### PR DESCRIPTION
The flood-risk-back-office requires govuk_admin_template which
requires jquery-rails 3.1, and we previously required ~> 4.1
- hence making the versions incompatible and bundler unable to
resolve the dependencies.