### PR TITLE
Revert to using ADDRESS_FACADE_* vars across all environments

### DIFF
--- a/config/initializers/check_for_presence_of_required_env_vars.rb
+++ b/config/initializers/check_for_presence_of_required_env_vars.rb
@@ -2,8 +2,8 @@
 # errors, for example email failing on first execution because of missing configuration.
 # You can add these variables in development or CI using your .env file.
 %w(SECRET_KEY_BASE
-   ADDRESS_FACADE_TEST_SERVER
-   ADDRESS_FACADE_TEST_PORT
+   ADDRESS_FACADE_SERVER
+   ADDRESS_FACADE_PORT
    ADDRESS_FACADE_CLIENT_ID
    ADDRESS_FACADE_KEY).each do |key|
   ENV.fetch(key) { raise "#{key} not found in ENV" }

--- a/spec/dummy/.env.example
+++ b/spec/dummy/.env.example
@@ -8,7 +8,7 @@ PG_PASSWORD = "password"
 
 SECRET_KEY_BASE: ab22062e002d232c2aed8996d48a47bbd6916c34c62d5eb0584769a2611c1f0dd83a6220f5d4d682
 
-ADDRESS_FACADE_TEST_SERVER = "[secret url to test dummy facade server]"
-ADDRESS_FACADE_TEST_PORT = 80
+ADDRESS_FACADE_SERVER = "[secret url to test dummy facade server]"
+ADDRESS_FACADE_PORT = 80
 ADDRESS_FACADE_CLIENT_ID = "example team1"
 ADDRESS_FACADE_KEY = "client1"

--- a/spec/dummy/config/secrets.yml
+++ b/spec/dummy/config/secrets.yml
@@ -17,11 +17,7 @@ defaults: &defaults
 development:
   <<: *defaults
   secret_key_base: bad2f8e96dd27b54f0e86ece59c1027e8286cc120765dc7de682b13d423497c21ad641018d6f5c2cf6633f7ee6631a714f12d9ae9f5504634dec435d61d9408a
-  address_facade_server: <%= ENV['ADDRESS_FACADE_TEST_SERVER'] %>
-  address_facade_port: <%= ENV['ADDRESS_FACADE_TEST_PORT'] %>
 
 test:
   <<: *defaults
   secret_key_base: 14731485c0cfc5c2331c7de5da04126215a5e4c932cadc39da3371fbdd1b37d7e548216cdca6ecf8a3e7fa834ba5039e94a47a5c032772551607863dd632b8d6
-  address_facade_server: <%= ENV['ADDRESS_FACADE_TEST_SERVER'] %>
-  address_facade_port: <%= ENV['ADDRESS_FACADE_TEST_PORT'] %>


### PR DESCRIPTION
Having ADDRESS_FACADE_TEST_* variables for dev and test environments
was adding uneccesary complexity in the engine and front end.