### PR TITLE
RIP-183 Make site description mandatory

### DIFF
--- a/app/forms/flood_risk_engine/steps/grid_reference_form.rb
+++ b/app/forms/flood_risk_engine/steps/grid_reference_form.rb
@@ -33,6 +33,9 @@ module FloodRiskEngine
       property :description
       validates(
         :description,
+        presence: {
+          message: t(".errors.description.blank")
+        },
         length: {
           maximum: 500,
           message: t(".errors.description.too_long", max: 500)

--- a/config/locales/flood_risk_engine/enrollments/steps/_grid_reference.en.yml
+++ b/config/locales/flood_risk_engine/enrollments/steps/_grid_reference.en.yml
@@ -35,6 +35,7 @@ en:
               blank: Enter a grid reference
             description:
               too_long: The site name or description must be no longer than %{max} characters
+              blank: Enter a site name or description
             dredging_length:
               blank: Enter the approximate length of dredging
               too_long: The length of dredging must be no longer than %{max} characters

--- a/spec/forms/flood_risk_engine/steps/grid_reference_form_spec.rb
+++ b/spec/forms/flood_risk_engine/steps/grid_reference_form_spec.rb
@@ -98,6 +98,21 @@ module FloodRiskEngine
           end
         end
 
+        context "with a blank description" do
+          let(:description) { "" }
+          let(:error_message) { subject.errors.messages[:description] }
+
+          it "should return false" do
+            expect(subject.validate(params)).to eq(false)
+          end
+
+          it "should display the locale error message" do
+            subject.validate(params)
+            expect(error_message)
+              .to eq([I18n.t("#{locale_key}.errors.description.blank")])
+          end
+        end
+
         context "with a long description" do
           let(:description) { Faker::Lorem.characters(501) }
           let(:error_message) { subject.errors.messages[:description] }


### PR DESCRIPTION
It was previously an optional field, now its mandatory.