### PR TITLE
Limited company registration number page - RIP-81

### DIFF
--- a/app/factories/flood_risk_engine/steps/form_object_factory.rb
+++ b/app/factories/flood_risk_engine/steps/form_object_factory.rb
@@ -19,7 +19,6 @@ module FloodRiskEngine
             check_exemptions:                 Steps::NullForm,
             user_type:                        Steps::UserTypeForm,
             individual_name:                  Steps::NullForm,
-            limited_company_number:           Steps::NullForm,
             limited_liability_number:         Steps::NullForm,
             other:                            Steps::NullForm,
             partnership:                      Steps::NullForm,

--- a/app/forms/flood_risk_engine/steps/limited_company_address_form.rb
+++ b/app/forms/flood_risk_engine/steps/limited_company_address_form.rb
@@ -1,7 +1,7 @@
 module FloodRiskEngine
   module Steps
 
-    class LocalAuthorityAddressForm < BaseAddressForm
+    class LimitedCompanyAddressForm < BaseAddressForm
 
       def self.factory(enrollment)
         raise(FormObjectError, "No Organisation set for step #{enrollment.current_step}") unless enrollment.organisation
@@ -12,7 +12,7 @@ module FloodRiskEngine
       end
 
       def self.params_key
-        :local_authority_address
+        :limited_company_address
       end
 
       property :postcode, virtual: true
@@ -30,13 +30,6 @@ module FloodRiskEngine
 
       def initialize(model, enrollment)
         super(model, enrollment)
-
-        # Consensus is that the original drop down list should be displayed when a user clicks Back,
-        # If address fields required local_authority_address_back can include partials 'shared/address_fields'
-        # or 'shared/display_address'
-        partial = "flood_risk_engine/enrollments/steps/local_authority_address_back"
-
-        @partial_to_render = partial if enrollment.organisation.primary_address.present?
       end
 
     end

--- a/app/forms/flood_risk_engine/steps/limited_company_name_form.rb
+++ b/app/forms/flood_risk_engine/steps/limited_company_name_form.rb
@@ -1,0 +1,25 @@
+module FloodRiskEngine
+  module Steps
+    class LimitedCompanyNameForm < FloodRiskEngine::Steps::BaseForm
+
+      def self.factory(enrollment)
+        raise(FormObjectError, "No Organisation set for step #{enrollment.current_step}") unless enrollment.organisation
+        new(enrollment.organisation, enrollment)
+      end
+
+      def self.params_key
+        :limited_company_name
+      end
+
+      # Define the attributes on the inbound model, that you want included in your form/validation with
+      # property :name
+      # For full API see  - https://github.com/apotonick/reform
+      # property :company_name
+
+      # validates :company_name, presence: {
+      #    message:  I18n.t("#{LimitedCompanyNameForm.locale_key}.company_name.errors.blank")
+      # }
+
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/steps/limited_company_number_form.rb
+++ b/app/forms/flood_risk_engine/steps/limited_company_number_form.rb
@@ -1,0 +1,29 @@
+module FloodRiskEngine
+  module Steps
+    class LimitedCompanyNumberForm < FloodRiskEngine::Steps::BaseForm
+
+      def self.factory(enrollment)
+        raise(FormObjectError, "No Organisation set for step #{enrollment.current_step}") unless enrollment.organisation
+
+        new(enrollment.organisation, enrollment)
+      end
+
+      def self.params_key
+        :limited_company_number
+      end
+
+      property :registration_number
+
+      validates :registration_number, presence: {
+        message:  I18n.t("#{LimitedCompanyNumberForm.locale_key}.errors.blank")
+      }
+
+      validates :registration_number, 'ea/validators/companies_house_number':
+        {
+          allow_blank: true,
+          message: I18n.t("#{LimitedCompanyNumberForm.locale_key}.errors.invalid_html")
+        }
+
+    end
+  end
+end

--- a/app/forms/flood_risk_engine/steps/limited_company_postcode_form.rb
+++ b/app/forms/flood_risk_engine/steps/limited_company_postcode_form.rb
@@ -1,6 +1,6 @@
 module FloodRiskEngine
   module Steps
-    class LocalAuthorityPostcodeForm < BaseAddressSearchForm
+    class LimitedCompanyPostcodeForm < BaseAddressSearchForm
 
       def self.factory(enrollment)
         raise(FormObjectError, "No Organisation set for step #{enrollment.current_step}") unless enrollment.organisation
@@ -11,7 +11,7 @@ module FloodRiskEngine
       end
 
       def self.params_key
-        :local_authority_postcode
+        :limited_company_postcode
       end
 
       def validate(params)
@@ -19,7 +19,6 @@ module FloodRiskEngine
 
         # The target state for this address selection should we exit state machine and use address controller
         @target_step = :correspondence_contact_name if !result && manual_entry_enabled?
-
         result
       end
 

--- a/app/presenters/flood_risk_engine/enrollment_presenter.rb
+++ b/app/presenters/flood_risk_engine/enrollment_presenter.rb
@@ -38,6 +38,11 @@ module FloodRiskEngine
       title
     end
 
+    def organisation_registration_number
+      return unless enrollment.organisation && enrollment.organisation.registration_number.present?
+      enrollment.organisation.registration_number
+    end
+
     private
 
     attr_reader :enrollment

--- a/app/presenters/flood_risk_engine/tabular_enrollment_detail/row_builder.rb
+++ b/app/presenters/flood_risk_engine/tabular_enrollment_detail/row_builder.rb
@@ -65,6 +65,13 @@ module FloodRiskEngine
                   value: enrollment_presenter.correspondence_contact_telephone_number
       end
 
+      def organisation_registration_number_row
+        return unless enrollment_presenter.organisation_registration_number
+        build_row name: :company_number,
+                  value:  enrollment_presenter.organisation_registration_number,
+                  step: "#{organisation_type}_number"
+      end
+
       private
 
       # ==== Arguments

--- a/app/presenters/flood_risk_engine/tabular_enrollment_detail_presenter.rb
+++ b/app/presenters/flood_risk_engine/tabular_enrollment_detail_presenter.rb
@@ -27,10 +27,11 @@ module FloodRiskEngine
         row_builder.organisation_type_row,
         row_builder.organisation_name_row,
         row_builder.organisation_address_row,
+        row_builder.organisation_registration_number_row,
         row_builder.correspondence_contact_name_row,
         row_builder.correspondence_contact_telephone_row,
         row_builder.correspondence_contact_email_row
-      ].flatten!
+      ].flatten.compact
     end
 
     def row_builder

--- a/app/state_machines/flood_risk_engine/work_flow.rb
+++ b/app/state_machines/flood_risk_engine/work_flow.rb
@@ -24,7 +24,10 @@ module FloodRiskEngine
       def limited_company
         between_start_and_finish do
           [
-            :limited_company_number
+            :limited_company_number,
+            :limited_company_name,
+            :limited_company_postcode,
+            :limited_company_address
           ]
         end
       end

--- a/app/validators/ea/validators/companies_house_number_validator.rb
+++ b/app/validators/ea/validators/companies_house_number_validator.rb
@@ -1,0 +1,28 @@
+# Validates a company number.
+#   Valid numbers are:
+#     - two characters and 6 digits
+#     - 8 digits
+#
+# A company number consists of eight digits.
+# The first of these digits is usually a zero and because of this, in most cases only
+# the last seven numbers are usually required to be noted.
+# The certificate of incorporation of a new company will show only
+# the last seven numbers although the company number is actually eight digits and has a leading zero which is omitted.
+#
+module EA
+  module Validators
+
+    class CompaniesHouseNumberValidator < ActiveModel::EachValidator
+
+      VALID_COMPANIES_HOUSE_REGISTRATION_NUMBER_REGEX = Regexp.new(/\A(\d{8,8}$)|([a-zA-Z]{2}\d{6}$)\z/i).freeze
+
+      def validate_each(record, attribute, value)
+        value.strip!
+        unless value =~ VALID_COMPANIES_HOUSE_REGISTRATION_NUMBER_REGEX
+          record.errors.add attribute, (options[:message] || :invalid)
+        end
+      end
+    end
+
+  end
+end

--- a/app/views/flood_risk_engine/enrollments/steps/_limited_company_address.html.erb
+++ b/app/views/flood_risk_engine/enrollments/steps/_limited_company_address.html.erb
@@ -1,0 +1,45 @@
+<%= t('.postcode_hint') %>
+<p>
+  <%= form.postcode %>
+  <%= link_to t('.change'),
+              enrollment_step_path(form.enrollment, form.enrollment.previous_step),
+              class: 'change-postcode-button'
+  %>
+</p>
+
+<label class="form-label" for="address_match_selection">
+  <%= t('.select_from_list_label') %>
+</label>
+
+<fieldset>
+  <%= form_group_and_validation(form, :uprn) do %>
+    <%= f.select(
+          :uprn,
+          options_for_select( form.address_list.collect { |a| [ a[:moniker], a[:uprn] ] }),
+          {
+            include_blank: t('.num_addresses_found', num:  form.address_list.count)
+          },
+          {
+            class: 'form-control form-control-select form-control-char-auto',
+            id: 'address_match_selection'
+          }
+        )
+    %>
+  <% end %>
+</fieldset>
+
+<p>
+  <%=
+    link_to(
+      t('.manual_entry'),
+      new_address_path(
+        enrollment: form.enrollment,
+        addressable: form.enrollment.organisation,
+        postcode: form.postcode,
+        address_type: :primary,
+        step_back_to_postcode: true
+      ),
+      class: 'change-postcode-button'
+    )
+  %>
+</p>

--- a/app/views/flood_risk_engine/enrollments/steps/_limited_company_name.html.erb
+++ b/app/views/flood_risk_engine/enrollments/steps/_limited_company_name.html.erb
@@ -1,0 +1,18 @@
+
+<fieldset>
+  <legend class="visuallyhidden"><%= t('.legend') %></legend>
+
+  <!-- Company name -->
+  <div class="form-group">
+    <label class="form-label" for="company-name"><%= t('.label') %></label>
+    <%= form_group_and_validation(form, :company_name) do %>
+      <%#= f.text_field :company_name, class:  'form-control form-control-char-50' %>
+    <% end %>
+
+  </div>
+
+</fieldset>
+
+
+
+

--- a/app/views/flood_risk_engine/enrollments/steps/_limited_company_number.html.erb
+++ b/app/views/flood_risk_engine/enrollments/steps/_limited_company_number.html.erb
@@ -1,1 +1,11 @@
-limited_company_number
+<fieldset>
+  <legend class="visuallyhidden"><%= t('.legend') %></legend>
+
+  <%= form_group_and_validation(form, :registration_number) do %>
+    <label class="form-label" for="company-registration-number"><%= t('.label') %></label>
+    <span class="form-hint"><%= t('.hint') %></span>
+
+    <%= f.text_field :registration_number, class:  'form-control form-control-char-10' %>
+  <% end %>
+</fieldset>
+

--- a/app/views/flood_risk_engine/enrollments/steps/_limited_company_postcode.html.erb
+++ b/app/views/flood_risk_engine/enrollments/steps/_limited_company_postcode.html.erb
@@ -1,0 +1,26 @@
+<fieldset>
+  <legend class="visuallyhidden"><%= t('.legend') %></legend>
+
+  <%= form_group_and_validation(form, :postcode) do -%>
+    <%= f.label :postcode,  t('.label') , class: 'form-label' %>
+    <span class="form-hint"><%= t('.hint') %></span>
+    <%= f.text_field 'postcode', class: 'form-control form-postcode form-control-char-10' %>
+  <% end %>
+
+  <% if(form.manual_entry_enabled?) %>
+    <p>
+      <%= link_to( t('flood_risk_engine.enrollments.addresses.manual_entry'),
+                   new_address_path( enrollment: form.enrollment,
+                                     addressable: form.enrollment.organisation,
+                                     postcode: form.postcode,
+                                     address_type: :primary,
+                                     step_back_to_postcode: false,
+                                     target_step: form.target_step
+                   ),
+                   class: 'change-postcode-button'
+          )
+      %>
+    </p>
+  <% end  %>
+
+</fieldset>

--- a/config/initializers/address_lookup.rb
+++ b/config/initializers/address_lookup.rb
@@ -4,7 +4,7 @@ EA::AddressLookup.configure do |config|
   config.address_facade_url     = "/address-service/v1/addresses/postcode"
 
   # 5 was causing many timeouts in development
-  config.timeout_in_seconds     = 10
-  config.address_facade_client_id =  Rails.application.secrets.address_facade_client_id
-  config.address_facade_key       =  Rails.application.secrets.address_facade_key
+  config.timeout_in_seconds       = Rails.application.secrets.address_facade_timeout
+  config.address_facade_client_id = Rails.application.secrets.address_facade_client_id
+  config.address_facade_key       = Rails.application.secrets.address_facade_key
 end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,0 +1,3 @@
+ActiveSupport::Inflector.inflections do |inflect|
+  inflect.acronym 'EA'
+end

--- a/config/locales/flood_risk_engine/enrollments/steps/_check_your_answers.en.yml
+++ b/config/locales/flood_risk_engine/enrollments/steps/_check_your_answers.en.yml
@@ -10,6 +10,9 @@ en:
           table_summary: The information you've given so far with links to change the data
           change_link: Change
           rows:
+            company_number:
+              title: Company Number
+              accessible_change_link_suffix: company number
             organisation_type:
               title: Customer type
               accessible_change_link_suffix: customer type

--- a/config/locales/flood_risk_engine/enrollments/steps/_limited_company_address.en.yml
+++ b/config/locales/flood_risk_engine/enrollments/steps/_limited_company_address.en.yml
@@ -1,0 +1,13 @@
+---
+en:
+  flood_risk_engine:
+    enrollments:
+      steps:
+        limited_company_address:
+          change: Change
+          heading: "What’s the registered address of the Company"
+          legend: Address
+          manual_entry: "I can’t find the address in the list"
+          num_addresses_found: "%{num} addresses found"
+          postcode_hint: Postcode
+          select_from_list_label: Address

--- a/config/locales/flood_risk_engine/enrollments/steps/_limited_company_name.en.yml
+++ b/config/locales/flood_risk_engine/enrollments/steps/_limited_company_name.en.yml
@@ -1,0 +1,9 @@
+---
+en:
+  flood_risk_engine:
+    enrollments:
+      steps:
+        limited_company_name:
+          heading: What's the registered name of the company?
+          label: Registered name of company
+          legend: Registered company name

--- a/config/locales/flood_risk_engine/enrollments/steps/_limited_company_number.en.yml
+++ b/config/locales/flood_risk_engine/enrollments/steps/_limited_company_number.en.yml
@@ -1,0 +1,15 @@
+---
+en:
+  flood_risk_engine:
+    enrollments:
+      steps:
+        limited_company_number:
+          errors:
+              blank: Enter the company registration number
+              invalid_html: Enter a valid number - it should have 8 digits, or 2 letters followed by 6 digits
+                </br>If your number has only 7 digits, enter it with a zero at the start.
+          heading: What's the registration number of the company?
+          label: Company registration number
+          hint: An 8 digit number, or 2 letters followed by a 6 digit number
+          legend: Registration number of the company
+

--- a/config/locales/flood_risk_engine/enrollments/steps/_limited_company_postcode.en.yml
+++ b/config/locales/flood_risk_engine/enrollments/steps/_limited_company_postcode.en.yml
@@ -1,0 +1,10 @@
+---
+en:
+  flood_risk_engine:
+    enrollments:
+      steps:
+        limited_company_postcode:
+          heading: "What’s the registered address of the Company"
+          label:  UK postcode
+          hint: "For example, BS1 5AH"
+          legend: Postcode

--- a/db/migrate/20160601092629_change_company_num_to_reg_number.rb
+++ b/db/migrate/20160601092629_change_company_num_to_reg_number.rb
@@ -1,0 +1,10 @@
+class ChangeCompanyNumToRegNumber < ActiveRecord::Migration
+  def change
+
+    remove_column :flood_risk_engine_organisations, :company_number
+
+    add_column :flood_risk_engine_organisations, :registration_number, :string, limit: 12
+
+    add_index :flood_risk_engine_organisations, :registration_number
+  end
+end

--- a/spec/controllers/flood_risk_engine/enrollments/steps_controller/check_your_details_spec.rb
+++ b/spec/controllers/flood_risk_engine/enrollments/steps_controller/check_your_details_spec.rb
@@ -6,7 +6,7 @@ module FloodRiskEngine
 
     let(:enrollment) do
       create(:enrollment,
-             :with_locale_authority,
+             :with_local_authority,
              :with_exemption,
              :with_exemption_location,
              step: step)

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160526153044) do
+ActiveRecord::Schema.define(version: 20160601092629) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -125,14 +125,15 @@ ActiveRecord::Schema.define(version: 20160526153044) do
   create_table "flood_risk_engine_organisations", force: :cascade do |t|
     t.string   "name"
     t.integer  "contact_id"
-    t.string   "company_number"
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
     t.integer  "org_type"
+    t.string   "registration_number", limit: 12
   end
 
   add_index "flood_risk_engine_organisations", ["contact_id"], name: "index_flood_risk_engine_organisations_on_contact_id", using: :btree
   add_index "flood_risk_engine_organisations", ["org_type"], name: "index_flood_risk_engine_organisations_on_org_type", using: :btree
+  add_index "flood_risk_engine_organisations", ["registration_number"], name: "index_flood_risk_engine_organisations_on_registration_number", using: :btree
 
   create_table "not_in_engines", force: :cascade do |t|
     t.string   "name"

--- a/spec/factories/enrollments.rb
+++ b/spec/factories/enrollments.rb
@@ -1,8 +1,16 @@
 FactoryGirl.define do
   factory :enrollment, class: "FloodRiskEngine::Enrollment" do
-    trait :with_locale_authority do
-      after(:build) do |object|
-        object.organisation = build :organisation, :as_local_authority
+    # Create a trait for each Type, in format : with_local_authority, etc
+    #   local_authority
+    #   limited_company
+    #   limited_liability_partnership
+    #   individual
+    #   partnership
+    #   other
+    #   unknown
+    FloodRiskEngine::Organisation.org_types.keys.each do |ot|
+      trait :"with_#{ot}" do
+        after(:build) { |object| object.organisation = create(:organisation, :"as_#{ot}") }
       end
     end
 

--- a/spec/factories/organisations.rb
+++ b/spec/factories/organisations.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :organisation, class: "FloodRiskEngine::Organisation" do
     org_type 0
     name Faker::Company.name
-    company_number Faker::Number.number(8)
+    registration_number Faker::Number.number(8)
 
     after(:build) do |object|
       object.contact = FloodRiskEngine::Contact.create(contact_type: :establishment_or_undertaking)
@@ -12,6 +12,7 @@ FactoryGirl.define do
     FloodRiskEngine::Organisation.org_types.keys.each do |ot|
       trait :"as_#{ot}" do
         org_type ot.to_s
+        registration_number ""
       end
     end
   end

--- a/spec/factories/page_related_enrollments_factory.rb
+++ b/spec/factories/page_related_enrollments_factory.rb
@@ -4,7 +4,15 @@ FactoryGirl.define do
   factory :page_check_location, class: FloodRiskEngine::Enrollment do
   end
 
-  factory :page_local_authority, parent: :enrollment, traits: [:with_exemption, :with_locale_authority] do
+  factory :page_user_type, parent: :enrollment do
+    step :user_type
+  end
+
+  # Paths
+
+  # Local Authority
+
+  factory :page_local_authority, parent: :page_user_type, traits: [:with_exemption, :with_local_authority] do
     step :local_authority
   end
 
@@ -26,6 +34,14 @@ FactoryGirl.define do
 
     step :local_authority_address
   end
+
+  # Ltd Company
+
+  factory :page_limited_company_number, parent: :page_user_type, traits: [:with_exemption, :with_limited_company] do
+    step :limited_company_number
+  end
+
+  # END PATHS
 
   factory :page_correspondence_contact, parent: :page_local_authority_address, traits: [:with_address] do
     trait :with_contact do

--- a/spec/forms/flood_risk_engine/steps/limited_company_number_form_spec.rb
+++ b/spec/forms/flood_risk_engine/steps/limited_company_number_form_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+require_relative "../../../support/shared_examples/form_objects"
+
+module FloodRiskEngine
+  module Steps
+
+    RSpec.describe Steps::LimitedCompanyNumberForm, type: :form do
+      let(:params_key) { :limited_company_number }
+
+      let(:enrollment) { create(:page_limited_company_number) }
+
+      let(:model_class) { FloodRiskEngine::Organisation } # needed for  it_behaves_like "a form object"
+
+      let(:form) { LimitedCompanyNumberForm.factory(enrollment) }
+
+      subject { form }
+
+      it_behaves_like "a form object"
+
+      it { is_expected.to be_a(LimitedCompanyNumberForm) }
+
+      it "is not redirectable" do
+        expect(form.redirect?).to_not be_truthy
+      end
+
+      let(:company_number) { "01234567" }
+
+      context "with valid params" do
+        let(:valid_attributes) {
+          { "#{form.params_key}": { registration_number: company_number } }
+        }
+
+        it "form validate returns true" do
+          expect(form.validate(valid_attributes)).to eq true
+        end
+
+        describe "Save" do
+          it "saves a valid company_number on enrollment's organisation" do
+            form.validate(valid_attributes)
+            expect(form.save).to eq true
+
+            expect(form.model.registration_number).to eq company_number
+
+            expect(Enrollment.last.organisation.registration_number).to eq company_number
+          end
+        end
+      end
+
+      context "with invalid params" do
+        let(:invalid_attributes) {
+          { "#{form.params_key}": { registration_number: "4567" } }
+        }
+
+        it "form validate returns false" do
+          expect(form.validate(invalid_attributes)).to eq false
+        end
+
+        it "form contains error realted to blank entry" do
+          form.validate("#{form.params_key}": { registration_number: nil })
+
+          expect(
+            subject.errors.messages[:registration_number]
+          ).to eq [I18n.t("#{LimitedCompanyNumberForm.locale_key}.errors.blank")]
+        end
+
+        it "form contains errors" do
+          form.validate(invalid_attributes)
+
+          expect(
+            form.errors.messages[:registration_number]
+          ).to eq [I18n.t("#{LimitedCompanyNumberForm.locale_key}.errors.invalid_html")]
+        end
+      end
+    end
+  end
+end

--- a/spec/presenters/flood_risk_engine/enrollment_presenter_spec.rb
+++ b/spec/presenters/flood_risk_engine/enrollment_presenter_spec.rb
@@ -4,7 +4,7 @@ module FloodRiskEngine
   RSpec.describe EnrollmentPresenter, type: :presenter do
     let(:enrollment) do
       build(:enrollment,
-            :with_locale_authority,
+            :with_local_authority,
             :with_organisation_address,
             :with_exemption,
             :with_exemption_location,

--- a/spec/validators/companies_house_number_validator_spec.rb
+++ b/spec/validators/companies_house_number_validator_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+module EA
+
+  RSpec.describe Validators::CompaniesHouseNumberValidator do
+    class ACompanyClass
+      include ActiveModel::Model
+      include ActiveModel::Validations
+
+      attr_accessor :number
+      validates :number, "ea/validators/companies_house_number": { allow_blank: true }
+    end
+
+    subject { ACompanyClass.new(number: number) }
+
+    context "when the number is valid in 8 digit format" do
+      let(:number) { "CH123456" }
+      it { is_expected.to be_valid }
+    end
+
+    context "when the number is valid in 2 chars + 6 digit format" do
+      let(:number) { "12345678" }
+      it { is_expected.to be_valid }
+    end
+
+    context "when the number is not 8 digits" do
+      %w(1234567 123456789).each do |invalid_number|
+        let(:number) { invalid_number }
+        it { is_expected.to_not be_valid }
+      end
+    end
+
+    context "when the number sis not 2 chars + 6 digits" do
+      %w(ZZ12345 AA1234567).each do |invalid_number|
+        let(:number) { invalid_number }
+        it { is_expected.to_not be_valid }
+      end
+    end
+    context "when the number has leading and trailing whitespace" do
+      let(:number) { "  XX123456  " }
+      it "trims whitespace before validating and leaves it trimmed" do
+        expect(subject).to be_valid
+        expect(subject.number).to eq number.strip
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Create generic companies house validator
Implement view, form and locale data
Rename company number, registration number, so more easily shared across organisation types

**N.B**
Stub forms/views for the two new states (following this state) so the journey in browser can still continue - therefore code for limited_company name and address should not be treated as QA ready