### PR TITLE
Make dredging length input numeric

### DIFF
--- a/app/forms/flood_risk_engine/steps/grid_reference_form.rb
+++ b/app/forms/flood_risk_engine/steps/grid_reference_form.rb
@@ -16,6 +16,10 @@ module FloodRiskEngine
         :grid_reference
       end
 
+      def self.config
+        FloodRiskEngine.config
+      end
+
       property :grid_reference
 
       validates(
@@ -49,10 +53,15 @@ module FloodRiskEngine
           message: t(".errors.dredging_length.blank"),
           if: :require_dredging_length?
         },
-        length: {
-          maximum: 25,
-          message: t(".errors.dredging_length.too_long", max: 25),
+        numericality: {
+          only_integer: true,
+          greater_than_or_equal_to: config.minumum_dredging_length_in_metres,
+          less_than_or_equal_to: config.maximum_dredging_length_in_metres,
           allow_blank: true,
+          message:
+            t(".errors.dredging_length.numeric",
+              min: config.minumum_dredging_length_in_metres,
+              max: config.maximum_dredging_length_in_metres),
           if: :require_dredging_length?
         }
       )

--- a/app/views/flood_risk_engine/enrollments/steps/_grid_reference.html.erb
+++ b/app/views/flood_risk_engine/enrollments/steps/_grid_reference.html.erb
@@ -48,11 +48,13 @@
         <span class="form-hint">
           <%= t(".dredging_length.clarification_hint") %>
         </span>
-        <%= f.text_field(
+        <%= f.number_field(
             :dredging_length,
+            min: FloodRiskEngine.config.minumum_dredging_length_in_metres,
+            max: FloodRiskEngine.config.maximum_dredging_length_in_metres,
             class: "form-control form-control-char-10",
             "aria-describedby" => "ngr_help")
-        %> metres
+        %> <%= t(".dredging_length.units") %>
       <% end %>
     <% end %>
   <% end %>

--- a/config/locales/flood_risk_engine/enrollments/steps/_grid_reference.en.yml
+++ b/config/locales/flood_risk_engine/enrollments/steps/_grid_reference.en.yml
@@ -15,6 +15,7 @@ en:
           dredging_length:
             form_label: Approximate length of dredging in metres
             clarification_hint: The maximum length you can dredge is 1,500 metres
+            units: metres
           description:
             form_label: Site name or description
             clarification_hint: |-
@@ -38,4 +39,4 @@ en:
               blank: Enter a site name or description
             dredging_length:
               blank: Enter the approximate length of dredging
-              too_long: The length of dredging must be no longer than %{max} characters
+              numeric: The length of dredging must be a number between %{min} and %{max}

--- a/lib/flood_risk_engine/configuration.rb
+++ b/lib/flood_risk_engine/configuration.rb
@@ -23,6 +23,8 @@ module FloodRiskEngine
     # The redirect URL for a popstcode lookup
     config_accessor(:redirection_url_postcode_lookup)
     config_accessor(:layout) { "application" }
+    config_accessor(:minumum_dredging_length_in_metres) { 1 }
+    config_accessor(:maximum_dredging_length_in_metres) { 1500 }
   end
 
   def self.config

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -37,5 +37,5 @@ Rails.application.configure do
   config.assets.raise_runtime_errors = true
 
   # Don't raise errors for missing translations
-  config.action_view.raise_on_missing_translations = false
+  config.action_view.raise_on_missing_translations = true
 end

--- a/spec/forms/flood_risk_engine/steps/grid_reference_form_spec.rb
+++ b/spec/forms/flood_risk_engine/steps/grid_reference_form_spec.rb
@@ -29,6 +29,12 @@ module FloodRiskEngine
         }
       end
 
+      let(:numeric_error_message) do
+        I18n.t("#{locale_key}.errors.dredging_length.numeric",
+               min: FloodRiskEngine.config.minumum_dredging_length_in_metres,
+               max: FloodRiskEngine.config.maximum_dredging_length_in_metres)
+      end
+
       describe "#validate" do
         let(:error_message) { subject.errors.messages[:grid_reference] }
         let(:locale_key) { described_class.locale_key }
@@ -136,8 +142,8 @@ module FloodRiskEngine
           end
 
           context "with dredging_length" do
-            let(:dredging_length) { "350m" }
-            it "should should validate" do
+            let(:dredging_length) { "350" }
+            it "should validate" do
               expect(subject.validate(params)).to eq(true)
             end
           end
@@ -155,15 +161,26 @@ module FloodRiskEngine
           end
 
           context "with too long a dredging_length" do
-            let(:dredging_length) { Faker::Lorem.characters(26) }
+            let(:dredging_length) { "150,000" }
             it "should return false" do
               expect(subject.validate(params)).to eq(false)
             end
 
             it "should display the locale error message" do
               subject.validate(params)
-              expect(error_message)
-                .to eq([I18n.t("#{locale_key}.errors.dredging_length.too_long", max: 25)])
+              expect(error_message).to eq([numeric_error_message])
+            end
+          end
+
+          context "with a dredging_length of zero" do
+            let(:dredging_length) { "0" }
+            it "should return false" do
+              expect(subject.validate(params)).to eq(false)
+            end
+
+            it "should display the locale error message" do
+              subject.validate(params)
+              expect(error_message).to eq([numeric_error_message])
             end
           end
         end

--- a/spec/lib/flood_risk_engine/configuration_spec.rb
+++ b/spec/lib/flood_risk_engine/configuration_spec.rb
@@ -13,5 +13,8 @@ module FloodRiskEngine
     end
 
     it { is_expected.to respond_to(:redirection_url_on_location_unchecked) }
+    it { is_expected.to respond_to(:layout) }
+    it { is_expected.to respond_to(:minumum_dredging_length_in_metres) }
+    it { is_expected.to respond_to(:maximum_dredging_length_in_metres) }
   end
 end


### PR DESCRIPTION
Leave the database column as a string in case we wish to revert to free-text.
Length should be between 1 and 1500 but configurable.