### PR TITLE
Update airbrake gem to try and resolve unwanted exception

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,7 +66,7 @@ GEM
     addressable (2.4.0)
     airbrake (5.3.0)
       airbrake-ruby (~> 1.3)
-    airbrake-ruby (1.3.1)
+    airbrake-ruby (1.3.2)
     arel (6.0.3)
     ast (2.2.0)
     autoprefixer-rails (6.3.6.1)


### PR DESCRIPTION
According to the airbrake-ruby changelog, 1.3.2 fixes the issue we are seeing.
The error we are seeing is
```Airbrake::Error (can't parse '/app/vendor/ruby-2.3.1/lib/ruby/2.3.0/net/http.rb:882:in `rescue in block in connect': Failed to open TCP connection to <redacted>:80 (getaddrinfo: Name or service not known) (SocketError)'):```
ie it seems to be having trouble parsing a certain type if exception.