### PR TITLE
Fix bug in regexp logic for company name

### DIFF
--- a/app/validators/ea/validators/companies_house_name_validator.rb
+++ b/app/validators/ea/validators/companies_house_name_validator.rb
@@ -11,8 +11,10 @@ module EA
 
     class CompaniesHouseNameValidator < ActiveModel::EachValidator
 
+      VALID_COMPANIES_HOUSE_NAME_REGEX = Regexp.new(/[\^|_~¬`]/).freeze
+
       def validate_each(record, attribute, value)
-        if value !~ CompaniesHouseNameValidator.valid_name_regex
+        if VALID_COMPANIES_HOUSE_NAME_REGEX.match(value)
           record.errors.add(
             attribute,
             (options[:message] || I18n.t("ea.validation_errors.companies_house_name.#{attribute}.invalid"))
@@ -24,8 +26,8 @@ module EA
         160
       end
 
-      def self.valid_name_regex
-        /\A[\p{Alpha}\p{N}][^\^|_~¬`]+\z/i
+      def self.disallowed_chars
+        @disallowed_chars ||= ["^", "|", "_", "~", "¬", "`"]
       end
 
     end

--- a/spec/cassettes/limited_company_postcode_address_service_400_test.yml
+++ b/spec/cassettes/limited_company_postcode_address_service_400_test.yml
@@ -1,0 +1,37 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://addressfacade.cloudapp.net/address-service/v1/addresses/postcode?client-id=example%20team1&key=client1&postcode=HR4G%200LE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc2 (linux-gnu x86_64) ruby/2.3.1p112
+      Host:
+      - addressfacade.cloudapp.net
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Fri, 03 Jun 2016 13:55:19 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"facade_status_code":400,"facade_error_message":"bad request to supplier
+        service","facade_error_code":"address_service_error_1","supplier_was_called":true,"supplier_status_code":400,"supplier_response":{"error":{"statuscode":400,"message":"Requested
+        postcode must contain a minimum of the sector plus 1 digit of the district
+        e.g. SO1. Requested postcode was HR4G0LE"}}}'
+    http_version: 
+  recorded_at: Fri, 03 Jun 2016 13:54:33 GMT
+recorded_with: VCR 3.0.1

--- a/spec/validators/companies_house_name_validator_spec.rb
+++ b/spec/validators/companies_house_name_validator_spec.rb
@@ -14,33 +14,39 @@ module EA
     subject { NameValidatable.new(name: name) }
 
     describe "Valid entry" do
+      after(:each) do
+        is_expected.to be_valid
+        expect(subject.errors[:name].size).to eq(0)
+      end
+
       context "With just normal chars" do
         let(:name) { "Joe Bloggs 123456 Ltd" }
-        it "is valid" do
-          is_expected.to be_valid
-          expect(subject.errors[:name].size).to eq(0)
-        end
+        it "is valid" do end
       end
 
       context "With just numbers" do
         let(:name) { "123456" }
-        it "is valid" do
-          is_expected.to be_valid
-          expect(subject.errors[:name].size).to eq(0)
-        end
+        it "is valid" do  end
       end
 
       context "With special but allowed chars" do
         let(:name) { "Joe @ Bloggs 123&456 * Ltd %$£" }
-        it "is valid" do
-          is_expected.to be_valid
-          expect(subject.errors[:name].size).to eq(0)
-        end
+        it "is valid" do end
+      end
+
+      context "With only a single special char" do
+        let(:name) { "@" }
+        it "is valid" do end
+      end
+
+      context "With only multiple special chara" do
+        let(:name) { "@ $$" }
+        it "is valid" do end
       end
     end
 
     describe "Disallowed special chars" do
-      ["^", "|", "_", "~", "¬", "`"].each do |char|
+      Validators::CompaniesHouseNameValidator.disallowed_chars.each do |char|
         context "when the name starts with #{char}" do
           let(:name) { "#{char}Joe Bloggs Ltd" }
           it "is invalid" do
@@ -50,7 +56,7 @@ module EA
         end
 
         context "when the name contain #{char}" do
-          let(:name) { "^Joe Bloggs#{char} Ltd" }
+          let(:name) { "Joe Bloggs#{char} Ltd" }
           it "is invalid" do
             is_expected.to_not be_valid
             expect(subject.errors[:name].size).to eq(1)
@@ -58,7 +64,7 @@ module EA
         end
 
         context "when the name ends with #{char}" do
-          let(:name) { "^Joe Bloggs Ltd#{char}" }
+          let(:name) { "Joe Bloggs Ltd#{char}" }
           it "is invalid" do
             is_expected.to_not be_valid
             expect(subject.errors[:name].size).to eq(1)


### PR DESCRIPTION
Simplify regexp matching
Resolves bug where a single special char raised invalid (even though that's a valid name)