### PR TITLE
Single exemptions RIP-201

### DIFF
--- a/app/forms/flood_risk_engine/steps/add_exemptions_form.rb
+++ b/app/forms/flood_risk_engine/steps/add_exemptions_form.rb
@@ -13,6 +13,7 @@ module FloodRiskEngine
         :exemption_ids,
         length: {
           minimum: 1,
+          maximum: 1,
           message: :select_at_lease_one_exemptions
         }
       )
@@ -22,8 +23,8 @@ module FloodRiskEngine
         @all_exemptions = Exemption.all
       end
 
-      def exemption_ids=(ids)
-        super ids.reject(&:blank?)
+      def exemption_ids=(id)
+        super [id]
       end
 
       def params_key

--- a/app/views/flood_risk_engine/enrollments/steps/_add_exemptions.html.erb
+++ b/app/views/flood_risk_engine/enrollments/steps/_add_exemptions.html.erb
@@ -1,14 +1,7 @@
 <p class="panel panel-border-wide">
-  <%=
-    t(
-      "flood_risk_engine.enrollments.steps.add_exemptions.lead_paragraph.text",
-      link: link_to(
-        t("flood_risk_engine.enrollments.steps.add_exemptions.lead_paragraph.link"),
-        "https://www.gov.uk/government/publications/environmental-permitting-regulations-exempt-flood-risk-activities",
-        target: "blank"
-      )
-    ).html_safe
-  %>
+  <%= t("flood_risk_engine.enrollments.steps.add_exemptions.lead_paragraph.text_1") %>
+  <br></br>
+  <%= t("flood_risk_engine.enrollments.steps.add_exemptions.lead_paragraph.text_2") %>
 </p>
 
 <fieldset>
@@ -16,15 +9,13 @@
     <%= t("flood_risk_engine.enrollments.steps.add_exemptions.heading") %>
   </legend>
   <%= form_group_and_validation(form, :base) do %>
-    <div class="form-group">
-      <%= f.collection_check_boxes( :exemption_ids, form.all_exemptions, :id, :code ) do |b|
-            b.label(class: "block-label exemption") do
-              b.check_box(data: { code: b.object.code }) + ' ' +
-              b.object.summary + ' ' +
-              content_tag('span', b.text, class: "exmpt")
-            end
+      <div class="form-group">
+        <%= f.collection_radio_buttons(:exemption_ids, form.all_exemptions, :id, :code) do |b|
+          b.label(class: "block-label exemption") do
+            b.radio_button + b.object.summary + ' ' + content_tag('span', b.text, class: "exmpt")
           end
-      %>
-    </div>
+        end
+        %>
+      </div>
   <% end %>
 </fieldset>

--- a/app/views/flood_risk_engine/enrollments/steps/_check_exemptions.html.erb
+++ b/app/views/flood_risk_engine/enrollments/steps/_check_exemptions.html.erb
@@ -35,14 +35,3 @@
     <% end %>
   </tbody>
 </table>
-
-<br />
-
-<p>
-  <%=
-    link_to(
-      t("flood_risk_engine.enrollments.steps.check_exemptions.add_link"),
-      enrollment_step_path(form.model, form.model.previous_step)
-    )
-  %>
-</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,7 +17,7 @@ en:
   activemodel:
     errors:
       messages:
-        select_at_lease_one_exemptions: Select at least one exemption
+        select_at_lease_one_exemptions: Select an exemption
 
   global:
     back: Back

--- a/config/locales/flood_risk_engine/enrollments/steps/_add_exemptions.en.yml
+++ b/config/locales/flood_risk_engine/enrollments/steps/_add_exemptions.en.yml
@@ -4,7 +4,8 @@ en:
     enrollments:
       steps:
         add_exemptions:
-          heading: Add the exemptions you want to register
+          heading: Select the exemption you want to register
           lead_paragraph:
-            text: You can register more than one exemption but they must all be at the same location. You must check you can meet the conditions for each exemption. %{link}.
+            text_1: You can only register one exemption at a time.
+            text_2: If you need more than one, please make a new registration for each.
             link: Exempt flood risk activities guidance

--- a/config/locales/flood_risk_engine/enrollments/steps/_check_exemptions.en.yml
+++ b/config/locales/flood_risk_engine/enrollments/steps/_check_exemptions.en.yml
@@ -4,9 +4,9 @@ en:
     enrollments:
       steps:
         check_exemptions:
-          heading: Check your exemptions
+          heading: Confirm your exemption
           add_link: Add another exemption
           remove_link:
-            text: Remove %{hidden}
+            text: Change %{hidden}
             hidden: exemption %{code}
           table_summary: Exemptions that you selected with title, exemption code and a link to remove any you don't need

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -129,13 +129,11 @@ ActiveRecord::Schema.define(version: 20160603150808) do
     t.datetime "created_at",                     null: false
     t.datetime "updated_at",                     null: false
     t.integer  "org_type"
-    t.integer  "primary_address_id"
     t.string   "registration_number", limit: 12
   end
 
   add_index "flood_risk_engine_organisations", ["contact_id"], name: "index_flood_risk_engine_organisations_on_contact_id", using: :btree
   add_index "flood_risk_engine_organisations", ["org_type"], name: "index_flood_risk_engine_organisations_on_org_type", using: :btree
-  add_index "flood_risk_engine_organisations", ["primary_address_id"], name: "index_flood_risk_engine_organisations_on_primary_address_id", using: :btree
   add_index "flood_risk_engine_organisations", ["registration_number"], name: "index_flood_risk_engine_organisations_on_registration_number", using: :btree
 
   create_table "not_in_engines", force: :cascade do |t|
@@ -161,6 +159,5 @@ ActiveRecord::Schema.define(version: 20160603150808) do
   add_foreign_key "flood_risk_engine_enrollments", "flood_risk_engine_organisations", column: "organisation_id"
   add_foreign_key "flood_risk_engine_enrollments_exemptions", "flood_risk_engine_enrollments", column: "enrollment_id"
   add_foreign_key "flood_risk_engine_enrollments_exemptions", "flood_risk_engine_exemptions", column: "exemption_id"
-  add_foreign_key "flood_risk_engine_organisations", "flood_risk_engine_addresses", column: "primary_address_id"
   add_foreign_key "flood_risk_engine_organisations", "flood_risk_engine_contacts", column: "contact_id"
 end

--- a/spec/forms/flood_risk_engine/steps/add_exemptions_form_spec.rb
+++ b/spec/forms/flood_risk_engine/steps/add_exemptions_form_spec.rb
@@ -6,8 +6,8 @@ module FloodRiskEngine
     let(:params_key) { :add_exemptions }
     let(:enrollment) { FactoryGirl.create(:enrollment) }
     let(:model_class) { Enrollment }
-    let(:exemptions) { FactoryGirl.create_list(:exemption, 3) }
-    let(:params) { { params_key => { exemption_ids: exemptions.collect(&:id) } } }
+    let(:exemption) { FactoryGirl.create(:exemption) }
+    let(:params) { { params_key => { exemption_ids: exemption.id } } }
 
     subject { described_class.factory(enrollment) }
 
@@ -23,26 +23,19 @@ module FloodRiskEngine
         subject.validate(params)
         subject.save
 
-        expect(enrollment.exemptions).to eq(exemptions)
+        expect(enrollment.exemptions.first).to eq(exemption)
       end
     end
 
     describe ".validate" do
       context "with empty exemptions params" do
-        let(:params) { { params_key => { exemption_ids: [] } } }
+        let(:params) { { params_key => {} } }
         let(:error_message) do
           I18n.t "activemodel.errors.messages.select_at_lease_one_exemptions"
         end
         it "should fail" do
           expect(subject.validate(params)).to be(false)
           expect(subject.errors.messages[:exemption_ids]).to eq([error_message])
-        end
-      end
-
-      context "with blank exemptions params" do
-        let(:params) { { params_key => { exemption_ids: [""] } } }
-        it "should fail" do
-          expect(subject.validate(params)).to be(false)
         end
       end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RIP-201

Previous functionality to enable a user to select multiple exemptions needs to be changed to restrict to one exemption.
Agreed solution is to change checkboxes to radio buttons

Change text for add exemptions page