### PR TITLE
Fix error where we were attempting to send to a blank email address

### DIFF
--- a/app/services/flood_risk_engine/send_enrollment_submitted_email.rb
+++ b/app/services/flood_risk_engine/send_enrollment_submitted_email.rb
@@ -25,7 +25,11 @@ module FloodRiskEngine
     end
 
     def distinct_recipients
-      [primary_contact_email, secondary_contact_email].map(&:strip).map(&:downcase).uniq
+      [primary_contact_email, secondary_contact_email]
+        .select(&:present?)
+        .map(&:strip)
+        .map(&:downcase)
+        .uniq
     end
 
     def primary_contact_email


### PR DESCRIPTION
When other (secondary contact) email is "" (which it is if nothing was entered
in that form) do not attempt to send to that address.