### PR TITLE
Add integration to codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,22 @@
+---
+engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - ruby
+      - javascript
+  fixme:
+    enabled: true
+  rubocop:
+    enabled: true
+  brakeman:
+    enabled: false
+  rubymotion:
+    enabled: true
+ratings:
+  paths:
+  - "**.module"
+  - "**.rb"
+exclude_paths:
+- spec/

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,3 +39,12 @@ branches:
   only:
     - master
     - develop
+
+# This section was added as per https://docs.travis-ci.com/user/code-climate/
+# To protect our codeclimate stats rather than adding the Codeclimate API key for this project
+# in the open we used this guide https://docs.travis-ci.com/user/encryption-keys/ to encryt the
+# value. Essentially install travis gem, then run `travis encrypt <my_code_climate_api_key>`
+addons:
+  code_climate:
+    repo_token:
+      secure: "g4gWCg+d/eN1TG0pfqH4gcPDj4m5I0NLFeutt5nQvfyfKjFzEgYwKtuEnfmAI80tiwzIZOkeUpMczsYPUWCbY1wM9WTqz4905bqpbYXD1Efzx8uMcUXXlctetMyur0lMBzxc8qTVJSEIwtZmjbZQHUFCmTeEVJYeIMHkoctprInQYm0YiU108KXmeIWleDcVODwNGIHO6RkyC7ug1/7Co9OU19D/9QWHXYXbOl8WtSMJKAwA/XAs5rxTebhPP92ROmd4C7wL3EobkFipKPrX5qAKx4TloB7aODD2c5BbOW8m/x20Y4PObBYlv1JVA7XxCMwg2lwGqr8IYvHaw0twP/ynJIKbX9GpisQ+2xAhCIeFaXC5Kt0dgMWcXIe0iHM32lJHnPJeDM4zB0C8+cIZ6z2xD6bNOVP0ItZERQLbay+HffgW2k6qt3U9q7+QCSpLnINl4VwJOQ+K/bMaz3bzolnrWXEEOqRvIH6FvCIUat9bHbzfZgti3hF3BjmC1hvIQGdMlNsTceJkyrk0xZz9k4NlhwseyiDUruZYfH//xgRSqj2dNTLpCEzhT0Zywn25IhHsKhQiXwIVewLoUbpF0bCESv24TcNgsjdoYGuR6d+Z/PVd1Lf7QuKC6QGPl1Bsq5LI9FadCw0gcpMqJwIfE9iE+EBV5LNEfsJaD0POZ1c="

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # FloodRiskEngine
 
 [![Build Status](https://travis-ci.org/EnvironmentAgency/flood-risk-engine.svg?branch=develop)](https://travis-ci.org/EnvironmentAgency/flood-risk-engine)
+[![Code Climate](https://codeclimate.com/github/EnvironmentAgency/flood-risk-engine/badges/gpa.svg)](https://codeclimate.com/github/EnvironmentAgency/flood-risk-engine)
 
 ## Development
 


### PR DESCRIPTION
This is part of our efforts to capture metrics about a project using codeclimate.

This change adds a `.codeclimate.yml` config file, plus updates the Travis-CI configuration to support pushing of test coverage stats to codeclimate, and an update to the README to display the codeclimate badge.