### PR TITLE
Add partnership step - where the name of a partner is entered.

### DIFF
--- a/app/factories/flood_risk_engine/steps/form_object_factory.rb
+++ b/app/factories/flood_risk_engine/steps/form_object_factory.rb
@@ -18,7 +18,6 @@ module FloodRiskEngine
             add_exemptions:                   Steps::AddExemptionsForm,
             check_exemptions:                 Steps::NullForm,
             user_type:                        Steps::UserTypeForm,
-            partnership:                      Steps::NullForm,
             check_your_answers:               Steps::CheckYourAnswersForm,
             declaration:                      Steps::NullForm
           }

--- a/app/forms/flood_risk_engine/steps/partnership_form.rb
+++ b/app/forms/flood_risk_engine/steps/partnership_form.rb
@@ -1,0 +1,48 @@
+module FloodRiskEngine
+  module Steps
+    class PartnershipForm < BaseForm
+      def self.factory(enrollment)
+        contact = Contact.new
+        new(contact, enrollment)
+      end
+
+      def self.params_key
+        :partnership
+      end
+
+      def self.max_length
+        70
+      end
+
+      # Used to work out whether this is the first partner being created.
+      # The count is effectively, the number of partners already built,
+      # plus the one being built. So the total number of partners.
+      # Counting this way makes the translations easier (:one and :other syntax)
+      def partner_count
+        enrollment.organisation.partners.count + 1
+      end
+
+      property :full_name
+
+      validates(
+        :full_name,
+        presence: {
+          message: t(".errors.full_name.blank")
+        },
+        "flood_risk_engine/text_field_content" => {
+          allow_blank: true
+        },
+        length: {
+          maximum: max_length,
+          message: t(".errors.full_name.too_long", max: max_length)
+        }
+      )
+
+      def save
+        super
+        enrollment.organisation.partners.create(contact: model)
+      end
+
+    end
+  end
+end

--- a/app/models/flood_risk_engine/organisation.rb
+++ b/app/models/flood_risk_engine/organisation.rb
@@ -2,6 +2,7 @@ module FloodRiskEngine
   class Organisation < ActiveRecord::Base
     belongs_to :contact
     has_one :enrollment, dependent: :restrict_with_exception
+    has_many :partners # Only needed for Partnerships
 
     enum org_type: {
       local_authority: 0,

--- a/app/models/flood_risk_engine/partner.rb
+++ b/app/models/flood_risk_engine/partner.rb
@@ -1,0 +1,8 @@
+module FloodRiskEngine
+  class Partner < ActiveRecord::Base
+    belongs_to :organisation
+    belongs_to :contact
+
+    delegate :full_name, :address, to: :contact
+  end
+end

--- a/app/views/flood_risk_engine/enrollments/steps/_partnership.html.erb
+++ b/app/views/flood_risk_engine/enrollments/steps/_partnership.html.erb
@@ -1,1 +1,22 @@
-partnership
+<div class="panel panel-border-wide">
+  <p><%= t(".information.main") %></p>
+  <p><%= t(".information.postscript") %></p>
+</div>
+
+<h2 class="heading-medium">
+  <%= t(".sub_heading", count: form.partner_count) %>
+</h2>
+
+<fieldset>
+  <legend class="visuallyhidden"><%= t(".legend") %></legend>
+
+  <!-- Full name -->
+  <%= form_group_and_validation(form, :full_name) do %>
+    <%= f.label :full_name, class: "form-label" do %>
+      <%= t(".full_name.label") %>
+      <span class="form-hint"><%= t(".full_name.hint") %></span>
+    <% end %>
+    <%= f.text_field :full_name, class: 'form-control form-control-char-35' %>
+  <% end %>
+
+</fieldset>

--- a/config/locales/flood_risk_engine/enrollments/steps/_partnership.en.yml
+++ b/config/locales/flood_risk_engine/enrollments/steps/_partnership.en.yml
@@ -1,0 +1,29 @@
+---
+en:
+  flood_risk_engine:
+    enrollments:
+      steps:
+        partnership:
+          heading: Partner names and addresses
+          information:
+            main: |-
+              We need to know the name and home address of all business partners
+              responsible for the activity.
+            postscript: You must give us the details of at least two partners.
+          sub_heading:
+            one: Add a business partner
+            other: Add another business partner
+          legend: Who's responsible for the activity?
+          full_name:
+            label: Full name
+            hint: For example, Jane Smith
+          errors:
+            full_name:
+              blank: Enter a name
+              too_short: Enter a full name
+              too_long: |-
+                Check the name you entered - it should have no more
+                than %{max} characters
+              content: |-
+                Make sure the name contains only letters, spaces, commas,
+                full stops, hyphens and apostrophes

--- a/db/migrate/20160613130542_create_flood_risk_engine_partners.rb
+++ b/db/migrate/20160613130542_create_flood_risk_engine_partners.rb
@@ -1,0 +1,21 @@
+class CreateFloodRiskEnginePartners < ActiveRecord::Migration
+  def change
+    create_table :flood_risk_engine_partners do |t|
+      t.integer :organisation_id, index: true
+      t.integer :contact_id, index: true
+      t.timestamps null: false
+    end
+
+    add_foreign_key(
+      :flood_risk_engine_partners,
+      :flood_risk_engine_organisations,
+      column: :organisation_id
+    )
+
+    add_foreign_key(
+      :flood_risk_engine_partners,
+      :flood_risk_engine_contacts,
+      column: :contact_id
+    )
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160603150808) do
+ActiveRecord::Schema.define(version: 20160613130542) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,9 +76,10 @@ ActiveRecord::Schema.define(version: 20160603150808) do
     t.integer  "organisation_id"
     t.string   "step",                      limit: 50
     t.integer  "correspondence_contact_id"
-    t.string   "token"
     t.integer  "secondary_contact_id"
+    t.string   "token"
     t.string   "reference_number",          limit: 12
+    t.boolean  "in_review"
     t.integer  "status",                               default: 0, null: false
   end
 
@@ -136,6 +137,16 @@ ActiveRecord::Schema.define(version: 20160603150808) do
   add_index "flood_risk_engine_organisations", ["org_type"], name: "index_flood_risk_engine_organisations_on_org_type", using: :btree
   add_index "flood_risk_engine_organisations", ["registration_number"], name: "index_flood_risk_engine_organisations_on_registration_number", using: :btree
 
+  create_table "flood_risk_engine_partners", force: :cascade do |t|
+    t.integer  "organisation_id"
+    t.integer  "contact_id"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+  end
+
+  add_index "flood_risk_engine_partners", ["contact_id"], name: "index_flood_risk_engine_partners_on_contact_id", using: :btree
+  add_index "flood_risk_engine_partners", ["organisation_id"], name: "index_flood_risk_engine_partners_on_organisation_id", using: :btree
+
   create_table "not_in_engines", force: :cascade do |t|
     t.string   "name"
     t.datetime "created_at", null: false
@@ -160,4 +171,6 @@ ActiveRecord::Schema.define(version: 20160603150808) do
   add_foreign_key "flood_risk_engine_enrollments_exemptions", "flood_risk_engine_enrollments", column: "enrollment_id"
   add_foreign_key "flood_risk_engine_enrollments_exemptions", "flood_risk_engine_exemptions", column: "exemption_id"
   add_foreign_key "flood_risk_engine_organisations", "flood_risk_engine_contacts", column: "contact_id"
+  add_foreign_key "flood_risk_engine_partners", "flood_risk_engine_contacts", column: "contact_id"
+  add_foreign_key "flood_risk_engine_partners", "flood_risk_engine_organisations", column: "organisation_id"
 end

--- a/spec/factories/partners.rb
+++ b/spec/factories/partners.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :partner, class: "FloodRiskEngine::Partner" do
+  end
+end

--- a/spec/forms/flood_risk_engine/steps/individual_form_spec.rb
+++ b/spec/forms/flood_risk_engine/steps/individual_form_spec.rb
@@ -52,7 +52,7 @@ module FloodRiskEngine
         end
       end
 
-      describe "#invalid" do
+      describe "#validate" do
         it "does not validate when no name supplied" do
           params = { "#{form.params_key}": { name: "" } }
 

--- a/spec/forms/flood_risk_engine/steps/other_form_spec.rb
+++ b/spec/forms/flood_risk_engine/steps/other_form_spec.rb
@@ -30,7 +30,9 @@ module FloodRiskEngine
 
           expect(form.enrollment.organisation.name).to eq(name)
         end
+      end
 
+      describe "#validate" do
         it "does not validate when no name supplied" do
           params = { form.params_key => { name: "" } }
 

--- a/spec/forms/flood_risk_engine/steps/partnership_form_spec.rb
+++ b/spec/forms/flood_risk_engine/steps/partnership_form_spec.rb
@@ -1,0 +1,97 @@
+require "rails_helper"
+require_relative "../../../support/shared_examples/form_objects"
+
+module FloodRiskEngine
+  module Steps
+
+    RSpec.describe PartnershipForm, type: :form do
+      let(:params_key) { :partnership }
+      let(:enrollment) { FactoryGirl.create(:enrollment, :with_partnership) }
+      let(:model_class) { FloodRiskEngine::Contact }
+      let(:name) { Faker::Name.name }
+      let!(:i18n_scope) { described_class.locale_key }
+      let(:form) { described_class.factory(enrollment) }
+
+      subject { form }
+
+      it_behaves_like "a form object"
+
+      it "has redirect? as false" do
+        expect(subject.redirect?).to eq(false)
+      end
+
+      describe "#validate" do
+        it "does not validate when no name supplied" do
+          params = { form.params_key => { full_name: "" } }
+
+          expect(form.validate(params)).to eq(false)
+          expect(subject.errors.messages[:full_name])
+            .to eq([I18n.t(".errors.full_name.blank", scope: i18n_scope)])
+        end
+
+        it "does not validate when name with unacceptable chars" do
+          params = { form.params_key => { full_name: "Fred *& " } }
+
+          expect(form.validate(params)).to eq(false)
+          expect(subject.errors.messages[:full_name])
+            .to eq([I18n.t("flood_risk_engine.validation_errors.name.invalid")])
+        end
+
+        it "does not validate when name supplied is too long" do
+          name = "bb" + ("a" * described_class.max_length)
+          params = { form.params_key => { full_name: name } }
+
+          expect(form.validate(params)).to eq(false)
+          expect(
+            subject.errors.messages[:full_name]
+          ).to eq(
+            [
+              I18n.t(
+                ".errors.full_name.too_long",
+                max: described_class.max_length,
+                scope: i18n_scope
+              )
+            ]
+          )
+        end
+      end
+
+      describe "#save" do
+        let(:params) { { form.params_key => { full_name: name } } }
+
+        before do
+          expect(form.validate(params)).to eq(true)
+        end
+
+        it "should create a new partner" do
+          expect { form.save }.to change { Partner.count }.by(1)
+        end
+
+        it "should create a new contact" do
+          expect { form.save }.to change { Contact.count }.by(1)
+        end
+
+        it "should save the name to the partner" do
+          form.save
+          expect(Partner.last.full_name).to eq(name)
+        end
+      end
+
+      describe "#partner_count" do
+        it "should return one when creating first partner" do
+          expect(form.partner_count).to eq(1)
+        end
+
+        context "with an existing partner" do
+          before do
+            enrollment.organisation.partners.create
+          end
+
+          it "should return the existing count of partners plus 1" do
+            expect(form.partner_count).to eq(Partner.count + 1)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/flood_risk_engine/organisation_spec.rb
+++ b/spec/models/flood_risk_engine/organisation_spec.rb
@@ -4,7 +4,7 @@ module FloodRiskEngine
   RSpec.describe Organisation, type: :model do
     it { is_expected.to belong_to(:contact) }
     it { is_expected.to have_one(:enrollment).dependent(:restrict_with_exception) }
-
     it { is_expected.to have_one(:primary_address).dependent(:restrict_with_exception) }
+    it { is_expected.to have_many(:partners) }
   end
 end

--- a/spec/models/flood_risk_engine/partner_spec.rb
+++ b/spec/models/flood_risk_engine/partner_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe Partner, type: :model do
+    it { is_expected.to belong_to(:contact) }
+    it { is_expected.to belong_to(:organisation) }
+  end
+end


### PR DESCRIPTION
See [RIP-89](https://eaflood.atlassian.net/browse/RIP-89)

I'll need to return to this page to ensure that when a user is sent back to this page, it allows them to add an additional partner (as in WEX). I have added some functionality in preparation for this (`form.partner_count`)