### PR TITLE
Remove redundant ENV var checks on engine start

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -14,6 +14,9 @@ engines:
     enabled: true
   rubocop:
     enabled: true
+    checks:
+      AllCops:
+        TargetRubyVersion: 2.3
   brakeman:
     enabled: false
   rubymotion:

--- a/config/initializers/1_check_for_presence_of_required_env_vars.rb
+++ b/config/initializers/1_check_for_presence_of_required_env_vars.rb
@@ -19,9 +19,6 @@ if Rails.env.production?
   %w(
     AIRBRAKE_HOST
     AIRBRAKE_PROJECT_KEY
-    EMAIL_USERNAME
-    EMAIL_PASSWORD
-    EMAIL_APP_DOMAIN
   ).each do |key|
     ENV.fetch(key) { raise "#{key} not found in ENV" }
   end


### PR DESCRIPTION
Remove checks for EMAIL_PASSWORD, EMAIL_USERNAME
and EMAIL_APP_DOMAIN as these are only for Heroku deployment
and are causing confusion as we deploy to
other platforms.
Also tell codeclimate we are using Ruby 2.3, so it will
reduce the amount of warnings it gives.