### PR TITLE
Chnage CodeClimate rubocop settings

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -15,8 +15,7 @@ engines:
   rubocop:
     enabled: true
     checks:
-      AllCops:
-        TargetRubyVersion: 2.3
+      Rubocop/AllCops/TargetRubyVersion: 2.3
   brakeman:
     enabled: false
   rubymotion:


### PR DESCRIPTION
Set TargetRubyVersion to 2.3 to reduce code climate warnings