### PR TITLE
Fix broken codeclimate rubocop engine settings

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -14,8 +14,7 @@ engines:
     enabled: true
   rubocop:
     enabled: true
-    checks:
-      Rubocop/AllCops/TargetRubyVersion: 2.3
+    config: '.codeclimate_rubocop.yml'
   brakeman:
     enabled: false
   rubymotion:

--- a/.codeclimate_rubocop.yml
+++ b/.codeclimate_rubocop.yml
@@ -1,0 +1,2 @@
+---
+inherit_from: https://raw.githubusercontent.com/EnvironmentAgency/before_commit/master/source/.rubocop.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.rubocop-*
 /.byebug_history
 .bundle/
 log/*.log


### PR DESCRIPTION
Add a .custom_rubocop.yml which inherits from before_commit's rubocop.yml url on github.
This means codeclimate will not warn on rubocop cops that we have turned off or adjusted.