### PR TITLE
Disable rubocop analysis on codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -13,12 +13,9 @@ engines:
   fixme:
     enabled: true
   rubocop:
-    enabled: true
-    config: '.codeclimate_rubocop.yml'
+    enabled: false
   brakeman:
     enabled: false
-  rubymotion:
-    enabled: true
 ratings:
   paths:
   - "**.module"

--- a/.codeclimate_rubocop.yml
+++ b/.codeclimate_rubocop.yml
@@ -1,2 +1,0 @@
----
-inherit_from: https://raw.githubusercontent.com/EnvironmentAgency/before_commit/master/source/.rubocop.yml


### PR DESCRIPTION
We do it during the build so it adds little to do it
again here. This decision was influenced by the fact that
we can't easily pull in the before_commit .rubocop.yml
for codeclimate to use (the ideal solution being to use
inherit_from <raw beforecommit rubocop.yml url>
from a .codeclimate_rubocop.yml
but this doesn't work because network connections are
unavailable on hosted codeclimate.)
Also remove the rubymotion engine as that was a stray.