### PR TITLE
Fix issues where manual address next page was wrong, and back issue

### DIFF
--- a/app/forms/flood_risk_engine/steps/base_address_form.rb
+++ b/app/forms/flood_risk_engine/steps/base_address_form.rb
@@ -32,14 +32,18 @@ module FloodRiskEngine
 
       # read only param for displaying the Postcode in the view
       def postcode
-        return enrollment.address_search.postcode if enrollment.address_search.postcode.present?
-
-        return enrollment.organisation.primary_address.postcode if enrollment.organisation.primary_address.present?
-
-        ""
+        address_search_postcode || primary_address_postcode || ""
       end
 
       protected
+
+      def address_search_postcode
+        enrollment.address_search.try(:postcode)
+      end
+
+      def primary_address_postcode
+        enrollment.organisation.try(:primary_address).try(:postcode)
+      end
 
       attr_reader :assignable_address
 

--- a/app/forms/flood_risk_engine/steps/other_postcode_form.rb
+++ b/app/forms/flood_risk_engine/steps/other_postcode_form.rb
@@ -15,7 +15,7 @@ module FloodRiskEngine
       end
 
       def target_step
-        :email_someone_else
+        :correspondence_contact_name
       end
     end
   end

--- a/spec/forms/flood_risk_engine/steps/other_address_form_spec.rb
+++ b/spec/forms/flood_risk_engine/steps/other_address_form_spec.rb
@@ -62,6 +62,25 @@ module FloodRiskEngine
           expect(address.addressable_type).to eq("FloodRiskEngine::Organisation")
         end
       end
+
+      describe "#address" do
+        context "when address_search is present but has no postcode" do
+          # This happens if an unrecognised postcode is used, and then
+          # address is entered manually, and the user returns to page from
+          # later in the journey
+          before do
+            enrollment.address_search = AddressSearch.new
+            enrollment.save
+            # ensure a primary address has been entered
+            form.validate(params)
+            expect(form.save).to eq true
+          end
+
+          it "should return the primary address postcode" do
+            expect(form.postcode).to eq(post_code)
+          end
+        end
+      end
     end
 
   end


### PR DESCRIPTION
From [RIP-230](https://eaflood.atlassian.net/browse/RIP-230) comment:

> Registration still misses out contact detail pages after address only if you use an unrecognised postcode (bs99 9xx) and enter the address manually.
> Also if you go back to the address page and select 'I can’t find the address in the list' it errors.