### PR TITLE
Fix/update errors and fix postcode error

### DIFF
--- a/app/forms/flood_risk_engine/steps/partnership_detail_form.rb
+++ b/app/forms/flood_risk_engine/steps/partnership_detail_form.rb
@@ -5,6 +5,12 @@ module FloodRiskEngine
         new(enrollment)
       end
 
+      def initialize(enrollment)
+        @enrollment = enrollment
+        remove_incomplete_partners
+        super(enrollment.reload)
+      end
+
       def save
         true
       end
@@ -15,6 +21,20 @@ module FloodRiskEngine
 
       def show_continue_button?
         enrollment.partners.count > 1
+      end
+
+      private
+
+      # If a user starts creating a partner and then goes back to the
+      # start of the process, then an incomplete partner can be created
+      # These need to be tidied up before progressing further.
+      def remove_incomplete_partners
+        enrollment.partners.each do |partner|
+          unless partner.address
+            partner.destroy
+            partner.contact.destroy
+          end
+        end
       end
     end
   end

--- a/app/views/flood_risk_engine/enrollments/steps/_partnership.html.erb
+++ b/app/views/flood_risk_engine/enrollments/steps/_partnership.html.erb
@@ -1,6 +1,5 @@
 <div class="panel panel-border-wide">
   <p><%= t(".information.main") %></p>
-  <p><%= t(".information.postscript") %></p>
 </div>
 
 <h2 class="heading-medium">

--- a/config/locales/flood_risk_engine/enrollments/steps/_partnership.en.yml
+++ b/config/locales/flood_risk_engine/enrollments/steps/_partnership.en.yml
@@ -7,7 +7,6 @@ en:
           heading: Partner names and addresses
           information:
             main: We need to know the name and home address of all business partners.
-            postscript: You must give us the details of at least two partners.
           sub_heading:
             one: Add a business partner
             other: Add another business partner

--- a/config/locales/flood_risk_engine/errors.en.yml
+++ b/config/locales/flood_risk_engine/errors.en.yml
@@ -4,37 +4,35 @@ en:
     errors:
       error_generic:
         heading: Something went wrong
-        sorry: |-
-          Sorry, there is a technical problem, which has been reported to
-          our support team.
-        clarification: If the problem persists, call the Environment Agency helpline 03708 506 506.
+        sorry: Sorry, there was a technical problem. It has been reported to our support team.
+        clarification: If it happens again, call the Environment Agency helpline 03708 506 506.
         try_again: Please try again in a few minutes.
       error_401:
         heading: Unauthorised
-        sorry: You are not permitted to see this page.
-        clarification: This page is restricted to certain users only.
+        sorry: Sorry, you need the correct login for this page.
+        clarification: This page is for staff and needs a login.
       error_403:
         # As per https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4
         # We do not wish to make this information available to the client, therefore using messaging for 404-not-found instead.
         heading: Page not found
         sorry: Sorry, the page you’re looking for cannot be found.
-        clarification: Please check the web address you entered was correct.
+        clarification: Please check the web address you entered is correct.
         link: Start again
       error_404:
         heading: Page not found
-        sorry: Sorry, the page you’re looking for cannot be found.
+        sorry: Sorry, we can't find that page.
         clarification: Please check the web address you entered was correct.
         link: Start again
       error_422:
-        heading: Unable to proceed
-        sorry: The change you wanted was rejected
-        clarification: Maybe you tried to change something you didn't have access to?
+        heading: There was a problem
+        sorry: Sorry, the system wasn't able to complete that step.
+        clarification: You could go back and try it again.
       error_step_not_valid:
-        heading: Unable to proceed
-        sorry: The page you have requested is not valid.
-        clarification: You are trying to get to a page that is not available at the current stage of your submission.
-        go_to_current_step: Return to current stage of submission
-        restart: Restart submission
+        heading: Registration step problem
+        sorry: Sorry, you can't go to that section of the registration.
+        clarification: Follow the link below to go back.
+        go_to_current_step: Go back to the last saved step
+        restart: Start registration again
 
 
 

--- a/spec/forms/flood_risk_engine/steps/partnership_detail_form_spec.rb
+++ b/spec/forms/flood_risk_engine/steps/partnership_detail_form_spec.rb
@@ -29,13 +29,34 @@ module FloodRiskEngine
         expect(subject.validate({})).to be(true)
       end
 
+      describe ".new" do
+        context "when incomplete partners exist" do
+          let(:incomplete_contact) { FactoryGirl.create(:contact, address: nil) }
+          before do
+            partner
+            FactoryGirl.create(
+              :partner,
+              contact: incomplete_contact,
+              organisation: enrollment.organisation
+            )
+            expect(enrollment.partners.count).to eq(2)
+          end
+
+          it "should remove the incomplete partner" do
+            expect { described_class.new(enrollment) }.to change(Partner, :count).by(-1)
+            expect(enrollment.reload.partners).to eq([partner])
+          end
+        end
+      end
+
       describe "show_continue_button?" do
         it "should start as false" do
           expect(subject.show_continue_button?).to be_falsy
         end
 
         context "there are more than one partners" do
-          let(:contact2) { FactoryGirl.create(:contact, address: address) }
+          let(:address2) { FactoryGirl.create(:address) }
+          let(:contact2) { FactoryGirl.create(:contact, address: address2) }
           before do
             partner
             FactoryGirl.create(


### PR DESCRIPTION
Martin has updated the texts of the error pages.

There is also a bug that occurs if a user starts creating a partner and then returns to the partnership page before an address is added to the partner. The result is creation of an incomplete partner. This PR includes a fix for that problem.