### PR TITLE
Fix error on completing partnership journey, and partners#show styling

### DIFF
--- a/app/assets/stylesheets/flood_risk_engine/application.css
+++ b/app/assets/stylesheets/flood_risk_engine/application.css
@@ -13,4 +13,3 @@
  *= require_tree .
  *= require_self
  */
-

--- a/app/views/flood_risk_engine/enrollments/partners/show.html.erb
+++ b/app/views/flood_risk_engine/enrollments/partners/show.html.erb
@@ -1,12 +1,17 @@
-<p>
+<h1 class="form-title heading-large">
   <%= t(".confirm_removal_of_partner", name: @partner.full_name) %>
-</p>
+</h1>
 <%= form_for(
       [@enrollment, @partner],
       url: delete_enrollment_partner_path(@enrollment, @partner),
       method: :post
     ) do |f| %>
-  <%= f.submit(t(".delete")) %>
+  <%= f.submit(t(".delete"), class: "button") %>
 <% end %>
 
-<%= link_to t(".cancel"), enrollment_step_path(@enrollment, @enrollment.current_step)  %>
+<%= link_to(
+      t(".cancel"),
+      enrollment_step_path(@enrollment, @enrollment.current_step),
+      style: "display:block;padding-top:30px;"
+    )
+%>

--- a/config/locales/flood_risk_engine/enrollment_mailer.en.yml
+++ b/config/locales/flood_risk_engine/enrollment_mailer.en.yml
@@ -41,3 +41,5 @@ en:
             title: Telephone
           correspondence_contact_email:
             title: Email
+          responsible_partner:
+            title: Details of responsible partner


### PR DESCRIPTION
An error was being raised when moving to completion for a partnership, because a translation was missing for the email generated.

The `partners#show` page was updates to match the comments in [RIP-94](https://eaflood.atlassian.net/browse/RIP-94)