### PR TITLE
Pin the reform gem verison

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,8 +17,8 @@ PATH
       os_map_ref (~> 0.4)
       phonelib (~> 0.6)
       rails (~> 4.2)
-      reform (~> 2.1)
-      reform-rails (~> 0.1)
+      reform (= 2.1.0)
+      reform-rails (= 0.1.0)
       uk_postcode (~> 2.1)
       validates_email_format_of (~> 1.6)
       virtus (~> 1.0)
@@ -111,13 +111,13 @@ GEM
       representable (>= 2.4.0, <= 3.1.0)
       uber
     docile (1.1.5)
-    domain_name (0.5.20160310)
+    domain_name (0.5.20160615)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.1.1)
     dotenv-rails (2.1.1)
       dotenv (= 2.1.1)
       railties (>= 4.0, < 5.1)
-    ea-address_lookup (0.3.2)
+    ea-address_lookup (0.3.3)
       activesupport (>= 4.2)
       nesty (~> 1.0)
       rest-client (~> 2.0.0.rc2)
@@ -201,7 +201,7 @@ GEM
     parser (2.3.1.2)
       ast (~> 2.2)
     pg (0.18.4)
-    phonelib (0.6.1)
+    phonelib (0.6.2)
     pkg-config (1.1.7)
     poltergeist (1.9.0)
       capybara (~> 2.1)
@@ -256,7 +256,7 @@ GEM
     representable (3.0.0)
       declarative (~> 0.0.5)
       uber (~> 0.0.15)
-    rest-client (2.0.0.rc3)
+    rest-client (2.0.0.rc4)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
@@ -374,4 +374,4 @@ DEPENDENCIES
   webmock (~> 1.24)
 
 BUNDLED WITH
-   1.12.3
+   1.12.5

--- a/flood_risk_engine.gemspec
+++ b/flood_risk_engine.gemspec
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/LineLength
 $LOAD_PATH.push File.expand_path("../lib", __FILE__)
 
 # Maintain your gem's version:
@@ -18,8 +19,8 @@ Gem::Specification.new do |s|
   s.test_files = Dir["spec/**/*"]
 
   s.add_dependency "rails", "~> 4.2"
-  s.add_dependency "reform", "~> 2.1"
-  s.add_dependency "reform-rails", "~> 0.1"
+  s.add_dependency "reform", "2.1.0" # Form object convenience - fixing this version as later versions cause issues
+  s.add_dependency "reform-rails", "0.1.0" # Form object convenience - fixing this version as later versions cause issues
   s.add_dependency "dotenv-rails", "~> 2.1"
   s.add_dependency "finite_machine", "~> 0.10"
   s.add_dependency "dibber", "~> 0.5" # Manages data seeding


### PR DESCRIPTION
Later versions of reform do not favour our
ActiveModel validations and consequently
cause issues. Unfortunately reform-rails does not
honour the same sematic versioning system as reform
so we have no choice but to pin both.