### PR TITLE
Allow same browser requirement to be configurable.

### DIFF
--- a/app/controllers/flood_risk_engine/enrollments/steps_controller.rb
+++ b/app/controllers/flood_risk_engine/enrollments/steps_controller.rb
@@ -61,6 +61,7 @@ module FloodRiskEngine
       end
 
       def check_journey_valid
+        return true unless FloodRiskEngine.config.require_journey_completed_in_same_browser
         return true if journey_tokens.include?(enrollment.token)
         raise(JourneyError, "Journey not started in current browser session")
       end

--- a/lib/flood_risk_engine/configuration.rb
+++ b/lib/flood_risk_engine/configuration.rb
@@ -22,10 +22,10 @@ module FloodRiskEngine
     config_accessor(:layout) { "application" }
     config_accessor(:minumum_dredging_length_in_metres) { 1 }
     config_accessor(:maximum_dredging_length_in_metres) { 1500 }
-
     config_accessor(:maximum_company_name_length) { 170 }
     config_accessor(:maximum_individual_name_length) { 170 }
     config_accessor(:maximum_llp_name_length) { 170 }
+    config_accessor(:require_journey_completed_in_same_browser) { true }
 
     config_accessor(:govuk_guidance_url) do
       "https://www.gov.uk/government/publications/"\

--- a/spec/controllers/flood_risk_engine/enrollments/steps_controller_spec.rb
+++ b/spec/controllers/flood_risk_engine/enrollments/steps_controller_spec.rb
@@ -16,6 +16,22 @@ module FloodRiskEngine
           get :show, id: step, enrollment_id: enrollment
           expect(response).to redirect_to(error_path(:step_not_valid))
         end
+
+        context "when app configured to allow another browser" do
+          let(:config) { FloodRiskEngine.config }
+          before do
+            config.require_journey_completed_in_same_browser = false
+          end
+
+          it "renders step page" do
+            get :show, id: step, enrollment_id: enrollment
+            expect(response).to have_http_status(:success)
+          end
+
+          after do
+            config.require_journey_completed_in_same_browser = true
+          end
+        end
       end
 
       context "step unknown" do

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -76,9 +76,10 @@ ActiveRecord::Schema.define(version: 20160622144823) do
     t.integer  "organisation_id"
     t.string   "step",                      limit: 50
     t.integer  "correspondence_contact_id"
-    t.string   "token"
     t.integer  "secondary_contact_id"
+    t.string   "token"
     t.string   "reference_number",          limit: 12
+    t.boolean  "in_review"
     t.integer  "status",                               default: 0, null: false
     t.datetime "submitted_at"
   end


### PR DESCRIPTION
Adds a configuration option to the engine, that is checked before checking that the same browser is used
through the user journey.

This modification will make it easier to turn off this functionality in the back office app.