### PR TITLE
Add comments model and associate with enrollment exemptions

### DIFF
--- a/app/helpers/flood_risk_engine/application_helper.rb
+++ b/app/helpers/flood_risk_engine/application_helper.rb
@@ -36,7 +36,7 @@ module FloodRiskEngine
       if form && form.errors[attribute].any?
         classes << "error"
         content = content_tag(:span,
-                              form.errors[attribute].first.to_s.html_safe,
+                              form.errors[attribute].first,
                               class: "error-message") + content
       end
       content_tag(:div, content, options.merge(class: classes.join(" ")))

--- a/app/models/flood_risk_engine/comment.rb
+++ b/app/models/flood_risk_engine/comment.rb
@@ -1,0 +1,6 @@
+module FloodRiskEngine
+  class Comment < ActiveRecord::Base
+    belongs_to :commentable, polymorphic: true
+    belongs_to(:user) if defined?(User)
+  end
+end

--- a/app/models/flood_risk_engine/enrollment_exemption.rb
+++ b/app/models/flood_risk_engine/enrollment_exemption.rb
@@ -4,6 +4,7 @@ module FloodRiskEngine
 
     belongs_to :enrollment, foreign_key: :enrollment_id
     belongs_to :exemption
+    has_many :comments, as: :commentable
 
     enum status: {
       building: 0,        # FO: anywhere before the confirmation step

--- a/db/migrate/20160624135831_create_flood_risk_engine_comments.rb
+++ b/db/migrate/20160624135831_create_flood_risk_engine_comments.rb
@@ -1,0 +1,12 @@
+class CreateFloodRiskEngineComments < ActiveRecord::Migration
+  def change
+    create_table :flood_risk_engine_comments do |t|
+      t.integer :user_id
+      t.references :commentable, polymorphic: true, index: {:name => "commentable_idx"}
+      t.text :content
+      t.string :event
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160622144823) do
+ActiveRecord::Schema.define(version: 20160624135831) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,6 +51,18 @@ ActiveRecord::Schema.define(version: 20160622144823) do
   add_index "flood_risk_engine_addresses", ["token"], name: "index_flood_risk_engine_addresses_on_token", unique: true, using: :btree
   add_index "flood_risk_engine_addresses", ["uprn"], name: "index_flood_risk_engine_addresses_on_uprn", using: :btree
 
+  create_table "flood_risk_engine_comments", force: :cascade do |t|
+    t.integer  "user_id"
+    t.integer  "commentable_id"
+    t.string   "commentable_type"
+    t.text     "content"
+    t.string   "event"
+    t.datetime "created_at",       null: false
+    t.datetime "updated_at",       null: false
+  end
+
+  add_index "flood_risk_engine_comments", ["commentable_type", "commentable_id"], name: "commentable_idx", using: :btree
+
   create_table "flood_risk_engine_contacts", force: :cascade do |t|
     t.integer  "contact_type",                            default: 0,  null: false
     t.integer  "title",                                   default: 0,  null: false
@@ -76,10 +88,9 @@ ActiveRecord::Schema.define(version: 20160622144823) do
     t.integer  "organisation_id"
     t.string   "step",                      limit: 50
     t.integer  "correspondence_contact_id"
-    t.integer  "secondary_contact_id"
     t.string   "token"
+    t.integer  "secondary_contact_id"
     t.string   "reference_number",          limit: 12
-    t.boolean  "in_review"
     t.integer  "status",                               default: 0, null: false
     t.datetime "submitted_at"
   end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -88,9 +88,10 @@ ActiveRecord::Schema.define(version: 20160624135831) do
     t.integer  "organisation_id"
     t.string   "step",                      limit: 50
     t.integer  "correspondence_contact_id"
-    t.string   "token"
     t.integer  "secondary_contact_id"
+    t.string   "token"
     t.string   "reference_number",          limit: 12
+    t.boolean  "in_review"
     t.integer  "status",                               default: 0, null: false
     t.datetime "submitted_at"
   end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :comment, class: "FloodRiskEngine::Comment" do
+    user_id nil
+    association :commentable, factory: :enrollment_exemption
+    content Faker::Lorem.paragraph
+    event Faker::Lorem.sentence
+  end
+end

--- a/spec/lib/flood_risk_engine/configuration_spec.rb
+++ b/spec/lib/flood_risk_engine/configuration_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 module FloodRiskEngine
   describe Configuration do
     subject { FloodRiskEngine.config }
-    it 'adds #config to the engine module' do
+    it "adds #config to the engine module" do
       expect(FloodRiskEngine).to respond_to(:config)
     end
 

--- a/spec/models/flood_risk_engine/comment_spec.rb
+++ b/spec/models/flood_risk_engine/comment_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+module FloodRiskEngine
+  RSpec.describe Comment, type: :model do
+    let(:comment) { FactoryGirl.create(:comment) }
+    it "can be associated with enrollment exemptions" do
+      expect(comment.commentable.class).to eq(EnrollmentExemption)
+    end
+  end
+end

--- a/spec/models/flood_risk_engine/enrollment/enrollment_rollback_to_spec.rb
+++ b/spec/models/flood_risk_engine/enrollment/enrollment_rollback_to_spec.rb
@@ -12,7 +12,7 @@ module FloodRiskEngine
     let(:enrollment) { create(:enrollment) }
     let(:steps) { TestStateMachine::WorkFlow.steps.collect!(&:to_s) }
 
-    describe '#rollback_to' do
+    describe "#rollback_to" do
       before do
         enrollment.go_forward
         enrollment.go_forward

--- a/spec/models/flood_risk_engine/enrollment_exemption_spec.rb
+++ b/spec/models/flood_risk_engine/enrollment_exemption_spec.rb
@@ -5,6 +5,7 @@ module FloodRiskEngine
     it { is_expected.to be_valid }
     it { is_expected.to respond_to(:expires_at) }
     it { is_expected.to respond_to(:valid_from) }
+    it { is_expected.to have_many(:comments) }
 
     context "Factories" do
       it "has a valid factory" do

--- a/spec/state_machines/flood_risk_engine/work_flow_spec.rb
+++ b/spec/state_machines/flood_risk_engine/work_flow_spec.rb
@@ -29,7 +29,7 @@ module FloodRiskEngine
       end
     end
 
-    describe '#for' do
+    describe "#for" do
       it "should hash for Definition start array" do
         expect(WorkFlow.for(:start)).to eq(start_hash)
       end

--- a/spec/support/shared_examples/form_objects.rb
+++ b/spec/support/shared_examples/form_objects.rb
@@ -1,17 +1,17 @@
 require "spec_helper"
 
 RSpec.shared_examples_for "a form object" do
-  describe '#params_key' do
+  describe "#params_key" do
     it "returns the correct symbol for indexing into params" do
       expect(subject.params_key).to eq params_key
     end
   end
-  describe '#enrollment_id' do
+  describe "#enrollment_id" do
     it "returns the id of the enrollment the form object was initialised with" do
       expect(subject.enrollment_id).to eq(enrollment.id)
     end
   end
-  describe '#model' do
+  describe "#model" do
     it "is the correct type" do
       expect(subject.model).to be_a(model_class)
     end


### PR DESCRIPTION
Comments are needed in the back office, but need to be associated with database objects defined in the engine, so defining model here.