### PR TITLE
RIP-163-164 Add a shared application version page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
-    before_commit (0.8.1)
+    before_commit (0.8.2)
     bootstrap-sass (3.3.6)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)

--- a/app/helpers/flood_risk_engine/application_helper.rb
+++ b/app/helpers/flood_risk_engine/application_helper.rb
@@ -67,6 +67,5 @@ module FloodRiskEngine
       args[0] = "flood_risk_engine.enrollments.steps.#{step}#{args.first}"
       t(*args)
     end
-
   end
 end

--- a/app/presenters/flood_risk_engine/application_version_page_presenter.rb
+++ b/app/presenters/flood_risk_engine/application_version_page_presenter.rb
@@ -1,0 +1,26 @@
+# A 'view model' behind the high_voltage static page @ /pages/version
+module FloodRiskEngine
+  class ApplicationVersionPagePresenter
+
+    def application_name
+      FloodRiskEngine.config.application_name || Rails.application.class.parent_name
+    end
+
+    def application_version
+      defined?(::Application::VERSION) ? Application::VERSION : "Undefined"
+    end
+
+    def git_commit
+      @git_commit ||= GitCommitSha.current
+    end
+
+    def git_commit_url
+      File.join(git_repository_url, "commit", git_commit)
+    end
+
+    def git_repository_url
+      FloodRiskEngine.config.git_repository_url ||
+        "https://github.com/EnvironmentAgency/#{application_name.underscore.dasherize}"
+    end
+  end
+end

--- a/app/views/pages/version.html.erb
+++ b/app/views/pages/version.html.erb
@@ -1,0 +1,25 @@
+<% presenter = FloodRiskEngine::ApplicationVersionPagePresenter.new %>
+
+<header>
+  <h1 class="heading-large"><%= presenter.application_name %></h1>
+</header>
+
+<section>
+  <p>
+    <label><%= t ('.app_version') %></label>
+    <strong><%= presenter.application_version %></strong>
+  </p>
+  <p>
+    <label><%= t('.commit') %></label>
+    <strong>
+      <%= link_to(presenter.git_commit,
+                  presenter.git_commit_url,
+                  target: "_blank",
+                  class: "btn-link") %>
+    </strong>
+  </p>
+  <p>
+    <label><%= t('.render_time') %></label>
+    <strong><%= l Time.zone.now %></strong>
+  </p>
+</section>

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,3 +1,3 @@
 ActiveSupport::Inflector.inflections do |inflect|
-  inflect.acronym 'EA'
+  inflect.acronym "EA"
 end

--- a/config/locales/pages/version.en.yml
+++ b/config/locales/pages/version.en.yml
@@ -1,0 +1,6 @@
+en:
+  pages:
+    version:
+      app_version: 'Application Version:'
+      commit: 'Commit hash:'
+      render_time: 'Page rendered at:'

--- a/lib/flood_risk_engine/configuration.rb
+++ b/lib/flood_risk_engine/configuration.rb
@@ -14,10 +14,6 @@ module FloodRiskEngine
   class Configuration
     include ActiveSupport::Configurable
 
-    # Define accessors here, e.g.
-    #   config_accessor(:some_key)
-    # or with an optional default
-    #   config_accessor(:some_key) { "a default value" }
     config_accessor(:redirection_url_postcode_lookup)
     config_accessor(:layout) { "application" }
     config_accessor(:minumum_dredging_length_in_metres) { 1 }
@@ -26,6 +22,8 @@ module FloodRiskEngine
     config_accessor(:maximum_individual_name_length) { 170 }
     config_accessor(:maximum_llp_name_length) { 170 }
     config_accessor(:require_journey_completed_in_same_browser) { true }
+    config_accessor(:git_repository_url) # Optionally used in pages/version
+    config_accessor(:application_name) # Optionally used in pages/version
 
     config_accessor(:govuk_guidance_url) do
       "https://www.gov.uk/government/publications/"\

--- a/lib/flood_risk_engine/git_commit_sha.rb
+++ b/lib/flood_risk_engine/git_commit_sha.rb
@@ -1,0 +1,31 @@
+module FloodRiskEngine
+  class GitCommitSha
+    def self.current
+      new.current
+    end
+
+    def current
+      sha = development_sha || capistrano_sha || heroku_sha
+      sha.present? && sha[0...7]
+    end
+
+    private
+
+    def development_sha
+      Rails.env.development? && `git rev-parse HEAD`
+    end
+
+    def heroku_sha
+      sha_from_file(".source_version")
+    end
+
+    def capistrano_sha
+      sha_from_file("REVISION")
+    end
+
+    def sha_from_file(filename)
+      file = Rails.root.join(filename)
+      File.exist?(file) && File.open(file, &:gets)
+    end
+  end
+end

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -2,4 +2,5 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+  helper FloodRiskEngine::ApplicationHelper
 end

--- a/spec/dummy/config/initializers/version.rb
+++ b/spec/dummy/config/initializers/version.rb
@@ -1,0 +1,3 @@
+class Application
+  VERSION = "0.0.1".freeze
+end

--- a/spec/dummy/config/locales/pages.en.yml
+++ b/spec/dummy/config/locales/pages.en.yml
@@ -1,0 +1,5 @@
+en:
+  pages:
+    version:
+      heading: Flood Risk Engine Dummy
+      repository_url: 'https://github.com/EnvironmentAgency/flood_risk_engine/commit/%{sha}'


### PR DESCRIPTION
This can be accessed from the FO or BO, and displays
* the application name, pulled from config or defaulting
  to the Application class name
* The application version, as defined by the host app
  in Application::VERSION
* the currently deployed git sha with a link to that commit,
  using the git repo url defined in a config setting, but
  defaulting to a github repo derived from the Application
  class name