### PR TITLE
Make EnrollmentExemption the status authority

### DIFF
--- a/app/models/flood_risk_engine/enrollment.rb
+++ b/app/models/flood_risk_engine/enrollment.rb
@@ -68,20 +68,9 @@ module FloodRiskEngine
       to: :state_machine
     )
 
-    enum status: {
-      building: 0,        # FO: anywhere before the confirmation step
-      pending: 1,         # FO: enrollment submitted and awaiting BO processing
-      being_processed: 2, # BO: prevents another admin user from processing it
-      approved: 3,        # BO: all checks pass
-      rejected: 4,        # BO: because e.g. grid ref in an SSI
-      expired: 5,         # BO: FRA23/24 only - expiry date has passed
-      withdrawn: 6        # BO: used to hide anything created in error
-    }
-
     def submit
       return if submitted_at.present?
       self.submitted_at = Time.zone.now
-      pending!
     end
 
     private

--- a/app/services/flood_risk_engine/send_enrollment_submitted_email.rb
+++ b/app/services/flood_risk_engine/send_enrollment_submitted_email.rb
@@ -19,8 +19,6 @@ module FloodRiskEngine
     attr_reader :enrollment
 
     def validate_enrollment
-      raise ArgumentError, "Enrollment argument not supplied" unless enrollment.present?
-      raise InvalidEnrollmentStateError, "Enrollment is not pending" unless enrollment.pending?
       raise MissingEmailAddressError, "Missing contact email address" if primary_contact_email.blank?
     end
 

--- a/app/services/flood_risk_engine/submit_enrollment_service.rb
+++ b/app/services/flood_risk_engine/submit_enrollment_service.rb
@@ -4,25 +4,25 @@
 module FloodRiskEngine
   class SubmitEnrollmentService
     attr_reader :enrollment
+    delegate :enrollment_exemptions, to: :enrollment
 
     def initialize(enrollment)
       @enrollment = enrollment
     end
 
     def finalize!
-      validate_enrollment
       enrollment.submit
+      set_enrollment_exemptions_to_pending
       SendEnrollmentSubmittedEmail.new(enrollment).call
     end
 
     private
 
-    def validate_enrollment
-      raise(ArgumentError, "Enrollment missing") if enrollment.nil?
-      unless enrollment.building?
-        raise InvalidEnrollmentStateError,
-              "Expected enrollment to have status 'building' but was '#{enrollment.status}'"
+    def set_enrollment_exemptions_to_pending
+      enrollment_exemptions.each do |enrollment_exemption|
+        enrollment_exemption.pending! if enrollment_exemption.building?
       end
     end
+
   end
 end

--- a/db/migrate/20160628122827_remove_flood_risk_engine_enrollment_status.rb
+++ b/db/migrate/20160628122827_remove_flood_risk_engine_enrollment_status.rb
@@ -1,0 +1,9 @@
+class RemoveFloodRiskEngineEnrollmentStatus < ActiveRecord::Migration
+  def up
+    remove_column :flood_risk_engine_enrollments, :status
+  end
+
+  def down
+    add_column :flood_risk_engine_enrollments, :status, :integer, default: 0, null: false
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160624135831) do
+ActiveRecord::Schema.define(version: 20160628122827) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -83,8 +83,8 @@ ActiveRecord::Schema.define(version: 20160624135831) do
 
   create_table "flood_risk_engine_enrollments", force: :cascade do |t|
     t.integer  "applicant_contact_id"
-    t.datetime "created_at",                                       null: false
-    t.datetime "updated_at",                                       null: false
+    t.datetime "created_at",                           null: false
+    t.datetime "updated_at",                           null: false
     t.integer  "organisation_id"
     t.string   "step",                      limit: 50
     t.integer  "correspondence_contact_id"
@@ -92,7 +92,6 @@ ActiveRecord::Schema.define(version: 20160624135831) do
     t.string   "token"
     t.string   "reference_number",          limit: 12
     t.boolean  "in_review"
-    t.integer  "status",                               default: 0, null: false
     t.datetime "submitted_at"
   end
 

--- a/spec/factories/enrollments.rb
+++ b/spec/factories/enrollments.rb
@@ -1,5 +1,6 @@
+# Factory fails unless class has be initiated, hence using :name method (\o/)
 FactoryGirl.define do
-  factory :enrollment, class: "FloodRiskEngine::Enrollment" do
+  factory :enrollment, class: FloodRiskEngine::Enrollment.name do
     # Create a trait for each Type, in format : with_local_authority, etc
     #   local_authority
     #   limited_company
@@ -8,7 +9,6 @@ FactoryGirl.define do
     #   partnership
     #   other
     #   unknown
-    status FloodRiskEngine::Enrollment.statuses[:building]
 
     FloodRiskEngine::Organisation.org_types.keys.each do |ot|
       trait :"with_#{ot}" do

--- a/spec/mailers/flood_risk_engine/enrollment_mailer_submitted_spec.rb
+++ b/spec/mailers/flood_risk_engine/enrollment_mailer_submitted_spec.rb
@@ -6,14 +6,25 @@ module FloodRiskEngine
     include EmailSpec::Helpers
     include EmailSpec::Matchers
 
-    before(:all) do
-      @recipient_address = "fred@example.com"
-      @enrollment = create(:enrollment,
-                           :with_correspondence_contact,
-                           :with_secondary_contact,
-                           status: Enrollment.statuses[:pending])
-      @email = EnrollmentMailer.submitted(enrollment_id: @enrollment.id,
-                                          recipient_address: @recipient_address)
+    let(:initial_status) { :building }
+    let(:enrollment_exemption) do
+      FactoryGirl.create(
+        :enrollment_exemption,
+        status: EnrollmentExemption.statuses[initial_status]
+      )
+    end
+    let(:enrollment) do
+      FactoryGirl.create(
+        :enrollment,
+        enrollment_exemptions: [enrollment_exemption]
+      )
+    end
+    let(:recipient_address) { Faker::Internet.safe_email }
+    let(:email) do
+      EnrollmentMailer.submitted(
+        enrollment_id: enrollment.id,
+        recipient_address: recipient_address
+      )
     end
 
     def t(key)
@@ -21,20 +32,20 @@ module FloodRiskEngine
     end
 
     it "generates a multipart message (plain text and html)" do
-      expect(@email.body.parts.length).to eq(2)
-      expect(@email.html_part).to_not be_nil
-      expect(@email.text_part).to_not be_nil
+      expect(email.body.parts.length).to eq(2)
+      expect(email.html_part).to_not be_nil
+      expect(email.text_part).to_not be_nil
     end
 
     let(:mail_yaml_key) { described_class.name.underscore.tr("/", ".") }
 
     it "renders the subject" do
-      expect(@email.subject).to_not match(/translation missing/)
-      expect(@email.subject).to eql(t(".subject"))
+      expect(email.subject).to_not match(/translation missing/)
+      expect(email.subject).to eql(t(".subject"))
     end
 
     it "has the receiver's email" do
-      expect(@email.to).to eql([@recipient_address])
+      expect(email.to).to eql([recipient_address])
     end
 
     it "has the sender's email" do
@@ -43,12 +54,12 @@ module FloodRiskEngine
       # return the Name part of the address - it will have been stripped out at this point.
       configured_sender = ENV["DEVISE_MAILER_SENDER"]
       expect(configured_sender).to be_present
-      expect(configured_sender).to match(/#{@email.from.first}/)
+      expect(configured_sender).to match(/#{email.from.first}/)
     end
 
     describe "content" do
       it "has no missing translations" do
-        expect(@email).to_not have_body_text(/translation missing/)
+        expect(email).to_not have_body_text(/translation missing/)
       end
     end
 
@@ -64,14 +75,14 @@ module FloodRiskEngine
            guidance.link_title
            your_responsibilities.heading
            your_responsibilities.body).each do |key|
-          expect(@email.text_part).to have_body_text(t(key))
-          expect(@email.html_part).to have_body_text(t(key))
+          expect(email.text_part).to have_body_text(t(key))
+          expect(email.html_part).to have_body_text(t(key))
         end
       end
 
       it "reference_number" do
-        expect(@email.text_part).to have_body_text(@enrollment.reference_number)
-        expect(@email.html_part).to have_body_text(@enrollment.reference_number)
+        expect(email.text_part).to have_body_text(enrollment.reference_number)
+        expect(email.html_part).to have_body_text(enrollment.reference_number)
       end
 
       # TODO: once format of email is confirmed, add tests for enrollment/exemption-specific

--- a/spec/services/flood_risk_engine/send_enrollment_submitted_email_spec.rb
+++ b/spec/services/flood_risk_engine/send_enrollment_submitted_email_spec.rb
@@ -3,26 +3,24 @@ require "rails_helper"
 module FloodRiskEngine
   RSpec.describe SendEnrollmentSubmittedEmail, type: :service do
     let(:mailer) { EnrollmentMailer }
+    let(:initial_status) { :pending }
+    let(:enrollment_exemption) do
+      FactoryGirl.create(
+        :enrollment_exemption,
+        status: EnrollmentExemption.statuses[initial_status]
+      )
+    end
     let(:enrollment) do
-      build_stubbed(:enrollment,
-                    :with_correspondence_contact,
-                    :with_secondary_contact,
-                    status: Enrollment.statuses[:pending])
+      FactoryGirl.create(
+        :enrollment,
+        :with_correspondence_contact,
+        :with_secondary_contact,
+        enrollment_exemptions: [enrollment_exemption]
+      )
     end
 
     describe "#call" do
       context "argument validation" do
-        it "raises an error when a nil enrollment passed" do
-          expect { described_class.new(nil).call }.to raise_error(ArgumentError)
-        end
-
-        it "raises an error if the enrollment is still building" do
-          enrollment.status = Enrollment.statuses[:building]
-          expect(enrollment.building?).to be true
-          error_class = InvalidEnrollmentStateError
-          expect { described_class.new(enrollment).call }.to raise_error(error_class)
-        end
-
         it "raises an error if there is no correspondence contact email address" do
           enrollment.correspondence_contact.email_address = ""
           error_class = MissingEmailAddressError
@@ -36,7 +34,6 @@ module FloodRiskEngine
           primary_contact_email   = enrollment.correspondence_contact.email_address
           secondary_contact_email = enrollment.secondary_contact.email_address
 
-          expect(enrollment).to be_pending
           expect(primary_contact_email).to be_present
           expect(secondary_contact_email).to be_present
           expect(primary_contact_email).to_not eq(secondary_contact_email)


### PR DESCRIPTION
Currently there is some ambiguity between `enrollment.status` and `enrollment_exemption.status`. 

This pull requests makes status belong to the enrollment exemptions