### PR TITLE
Move app-specific configuration out of the engine

### DIFF
--- a/config/initializers/address_lookup.rb
+++ b/config/initializers/address_lookup.rb
@@ -1,10 +1,4 @@
 EA::AddressLookup.configure do |config|
-  config.address_facade_server  = Rails.application.secrets.address_facade_server
-  config.address_facade_port    = Rails.application.secrets.address_facade_port
-  config.address_facade_url     = "/address-service/v1/addresses/postcode"
-
-  # 5 was causing many timeouts in development
-  config.timeout_in_seconds       = Rails.application.secrets.address_facade_timeout
-  config.address_facade_client_id = Rails.application.secrets.address_facade_client_id
-  config.address_facade_key       = Rails.application.secrets.address_facade_key
+   # Please configure address lookup url etc by adding a config/initialisers/address_lookup.rb
+   # in the host application
 end

--- a/config/initializers/area_lookup.rb
+++ b/config/initializers/area_lookup.rb
@@ -1,0 +1,4 @@
+EA::AreaLookup.configure do |config|
+ # Please configure area lookup url etc by adding a config/initialisers/area_lookup.rb
+ # in the host application
+end

--- a/lib/flood_risk_engine/engine.rb
+++ b/lib/flood_risk_engine/engine.rb
@@ -3,6 +3,7 @@ require "flood_risk_engine/exceptions"
 require "activerecord/session_store"
 require "high_voltage"
 require "ea/address_lookup"
+require "ea/area_lookup"
 require_dependency "virtus"
 
 module FloodRiskEngine

--- a/spec/dummy/config/initializers/address_lookup.rb
+++ b/spec/dummy/config/initializers/address_lookup.rb
@@ -1,10 +1,8 @@
 EA::AddressLookup.configure do |config|
-  config.address_facade_server  = Rails.application.secrets.address_facade_server
-  config.address_facade_port    = Rails.application.secrets.address_facade_port
-  config.address_facade_url     = "/address-service/v1/addresses/postcode"
-
-  # 5 was causing many timeouts in development
-  config.timeout_in_seconds     = 10
+  config.address_facade_server    = Rails.application.secrets.address_facade_server
+  config.address_facade_port      = Rails.application.secrets.address_facade_port
+  config.address_facade_url       = "/address-service/v1/addresses/postcode"
+  config.timeout_in_seconds       = 10 # 5 was causing many timeouts in development
   config.address_facade_client_id =  Rails.application.secrets.address_facade_client_id
   config.address_facade_key       =  Rails.application.secrets.address_facade_key
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -88,10 +88,9 @@ ActiveRecord::Schema.define(version: 20160629131906) do
     t.integer  "organisation_id"
     t.string   "step",                      limit: 50
     t.integer  "correspondence_contact_id"
-    t.integer  "secondary_contact_id"
     t.string   "token"
+    t.integer  "secondary_contact_id"
     t.string   "reference_number",          limit: 12
-    t.boolean  "in_review"
     t.datetime "submitted_at"
   end
 
@@ -144,11 +143,13 @@ ActiveRecord::Schema.define(version: 20160629131906) do
     t.datetime "created_at",                     null: false
     t.datetime "updated_at",                     null: false
     t.integer  "org_type"
+    t.integer  "primary_address_id"
     t.string   "registration_number", limit: 12
   end
 
   add_index "flood_risk_engine_organisations", ["contact_id"], name: "index_flood_risk_engine_organisations_on_contact_id", using: :btree
   add_index "flood_risk_engine_organisations", ["org_type"], name: "index_flood_risk_engine_organisations_on_org_type", using: :btree
+  add_index "flood_risk_engine_organisations", ["primary_address_id"], name: "index_flood_risk_engine_organisations_on_primary_address_id", using: :btree
   add_index "flood_risk_engine_organisations", ["registration_number"], name: "index_flood_risk_engine_organisations_on_registration_number", using: :btree
 
   create_table "flood_risk_engine_partners", force: :cascade do |t|
@@ -184,6 +185,7 @@ ActiveRecord::Schema.define(version: 20160629131906) do
   add_foreign_key "flood_risk_engine_enrollments", "flood_risk_engine_organisations", column: "organisation_id"
   add_foreign_key "flood_risk_engine_enrollments_exemptions", "flood_risk_engine_enrollments", column: "enrollment_id"
   add_foreign_key "flood_risk_engine_enrollments_exemptions", "flood_risk_engine_exemptions", column: "exemption_id"
+  add_foreign_key "flood_risk_engine_organisations", "flood_risk_engine_addresses", column: "primary_address_id"
   add_foreign_key "flood_risk_engine_organisations", "flood_risk_engine_contacts", column: "contact_id"
   add_foreign_key "flood_risk_engine_partners", "flood_risk_engine_contacts", column: "contact_id"
   add_foreign_key "flood_risk_engine_partners", "flood_risk_engine_organisations", column: "organisation_id"


### PR DESCRIPTION
Configuration for for example the address lookup gem
is in hindsight probably best done by the host app, rather than the
engine relying on ENV vars or Rails.application.secrets