### PR TITLE
Add engine version to version page

### DIFF
--- a/app/views/pages/version.html.erb
+++ b/app/views/pages/version.html.erb
@@ -19,6 +19,10 @@
     </strong>
   </p>
   <p>
+    <label><%= t ('.flood_risk_engine_version') %></label>
+    <strong><%= FloodRiskEngine::VERSION %></strong>
+  </p>
+  <p>
     <label><%= t('.render_time') %></label>
     <strong><%= l Time.zone.now %></strong>
   </p>

--- a/config/locales/pages/version.en.yml
+++ b/config/locales/pages/version.en.yml
@@ -1,6 +1,7 @@
 en:
   pages:
     version:
-      app_version: 'Application Version:'
+      app_version: 'Application version:'
       commit: 'Commit hash:'
+      flood_risk_engine_version: 'FloodRiskEngine version:'
       render_time: 'Page rendered at:'


### PR DESCRIPTION
Display the FloodRiskEngine version on the version page.