### PR TITLE
RIP-249 Display dredging and site info in rows

### DIFF
--- a/app/models/flood_risk_engine/enrollment_exemption.rb
+++ b/app/models/flood_risk_engine/enrollment_exemption.rb
@@ -16,5 +16,9 @@ module FloodRiskEngine
       withdrawn: 6        # BO: used to hide anything created in error
     }
 
+    def self.include_long_dredging?
+      includes(:exemption).where(flood_risk_engine_exemptions: { code: Exemption::LONG_DREDGING_CODES }).any?
+    end
+
   end
 end

--- a/app/presenters/flood_risk_engine/tabular_enrollment_detail/row_builder.rb
+++ b/app/presenters/flood_risk_engine/tabular_enrollment_detail/row_builder.rb
@@ -1,3 +1,4 @@
+# rubocop:disable ClassLength
 module FloodRiskEngine
   module TabularEnrollmentDetail
     class RowBuilder
@@ -40,6 +41,22 @@ module FloodRiskEngine
                   value: exemption.summary,
                   step: :add_exemptions,
                   code: exemption.code
+      end
+
+      def location_description_row
+        return unless enrollment_presenter.exemption_location
+        build_row name: :location_description,
+                  value: enrollment_presenter.exemption_location.description,
+                  step: :grid_reference
+      end
+
+      def location_dredging_length_row
+        return unless enrollment.enrollment_exemptions.include_long_dredging?
+        dredging_length = enrollment_presenter.exemption_location.dredging_length
+        formatted_dredging_length = ActiveSupport::NumberHelper.number_to_human(dredging_length, units: :distance)
+        build_row name: :dredging_length,
+                  value: formatted_dredging_length,
+                  step: :grid_reference
       end
 
       def organisation_name_row

--- a/app/presenters/flood_risk_engine/tabular_enrollment_detail_presenter.rb
+++ b/app/presenters/flood_risk_engine/tabular_enrollment_detail_presenter.rb
@@ -29,6 +29,8 @@ module FloodRiskEngine
       [
         row_builder.exemptions_rows,
         row_builder.grid_reference_row,
+        row_builder.location_description_row,
+        row_builder.location_dredging_length_row,
         row_builder.organisation_type_row,
         organisation_rows,
         row_builder.correspondence_contact_name_row,

--- a/config/locales/flood_risk_engine/enrollments/steps/_check_your_answers.en.yml
+++ b/config/locales/flood_risk_engine/enrollments/steps/_check_your_answers.en.yml
@@ -1,5 +1,9 @@
 ---
 en:
+  distance:
+    unit:
+      one: metre
+      other: metres
   flood_risk_engine:
     enrollments:
       steps:
@@ -22,6 +26,12 @@ en:
             exemption:
               title: Exemption %{code}
               accessible_change_link_suffix: exemption %{code}
+            location_description:
+              title: Site description
+              accessible_change_link_suffix: site description
+            dredging_length:
+              title: Dredging length
+              accessible_change_link_suffix: dredging length
             organisation_name:
               title: Responsible for activity (‘operator’)
               accessible_change_link_suffix: operator

--- a/spec/controllers/flood_risk_engine/enrollments/steps_controller/check_your_answers_spec.rb
+++ b/spec/controllers/flood_risk_engine/enrollments/steps_controller/check_your_answers_spec.rb
@@ -59,6 +59,15 @@ module FloodRiskEngine
         expect(response.body).to have_tag("#{tr} td", text: /#{value}/)
       end
 
+      it "location_description" do
+        tr = "table tbody tr[@data-row='location_description']"
+        expect(response.body).to have_selector(tr)
+        title = row_t(:location_description, :title)
+        expect(response.body).to have_tag("#{tr} th", text: /#{title}/)
+        value = enrollment.exemption_location.description
+        expect(response.body).to have_tag("#{tr} td", text: /#{value}/)
+      end
+
       it "organisation_type" do
         tr = "table tbody tr[@data-row='organisation_type']"
         expect(response.body).to have_selector(tr)
@@ -106,6 +115,23 @@ module FloodRiskEngine
 
       it "responsible_partner" do
         tr = "table tbody tr[@data-row='responsible_partner']"
+        expect(response.body).to have_selector(tr)
+      end
+    end
+
+    context "with dredging exemption" do
+      let(:enrollment) do
+        FactoryGirl.create(
+          :enrollment,
+          :with_partnership,
+          :with_dredging_exemption,
+          :with_exemption_location,
+          step: step
+        )
+      end
+
+      it "should include dredging length" do
+        tr = "table tbody tr[@data-row='dredging_length']"
         expect(response.body).to have_selector(tr)
       end
     end

--- a/spec/factories/enrollments.rb
+++ b/spec/factories/enrollments.rb
@@ -23,6 +23,14 @@ FactoryGirl.define do
       end
     end
 
+    trait :with_dredging_exemption do
+      after(:build) do |object|
+        dredging_code = FloodRiskEngine::Exemption::LONG_DREDGING_CODES.sample
+        exemption = create(:exemption, code: dredging_code)
+        object.enrollment_exemptions.build(exemption: exemption)
+      end
+    end
+
     trait :with_exemption_location do
       after(:build) do |object|
         object.exemption_location = build(:location)

--- a/spec/models/flood_risk_engine/enrollment_exemption_spec.rb
+++ b/spec/models/flood_risk_engine/enrollment_exemption_spec.rb
@@ -12,5 +12,18 @@ module FloodRiskEngine
         expect(build(:enrollment_exemption)).to be_valid
       end
     end
+
+    describe ".include_long_dredging?" do
+      before(:each) { FactoryGirl.create(:enrollment_exemption) }
+      it "returns true if the collection includes a long dredging exemption" do
+        dredging_code = FloodRiskEngine::Exemption::LONG_DREDGING_CODES.sample
+        dredging_exemption = create(:exemption, code: dredging_code)
+        FactoryGirl.create(:enrollment_exemption, exemption: dredging_exemption)
+        expect(described_class.include_long_dredging?).to be_truthy
+      end
+      it "returns false if the collection does not include a long dredging exemption" do
+        expect(described_class.include_long_dredging?).to be_falsey
+      end
+    end
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RIP-249

This only displays dredging length on the 'check your answers' page
if one of the enrollment exemptions is a long dredging exemption.

It always displays the location or site description on the 'check your
answers' page.

**Question for reviewer:** RowBuilder is now over 100 lines so I had to *disable the rubocop check* for class length here. Is that acceptable? If not, how would you approach this?