### PR TITLE
RIP-278 Add missing apostrophe to cookie page

### DIFF
--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -18,10 +18,9 @@
 
     <p>
       <%= t('.para_text1') %>
-      <%= link_to 'how to manage cookies on the Information Commissioners website',
+      <%= link_to "how to manage cookies on the Information Commissioner's website",
                   "https://ico.org.uk/for-the-public/online/cookies/",
-                  rel: 'external' %>
-      <%= t('.para_text2') %>
+                  rel: 'external' %>.
     </p>
     <h2 class="heading-medium">
       <%=  t('.heading_h2') %>

--- a/config/locales/pages/cookies.en.yml
+++ b/config/locales/pages/cookies.en.yml
@@ -60,7 +60,6 @@ en:
       list_item5: what you click on while you’re using the service
       para_text: 'These cookies are used to:'
       para_text1: Find out
-      para_text2: "."
       para_text3: We use Google Analytics to collect information about how you use
         the service. This information helps us to improve the service.
       para_text4: 'The Google analytics cookie collects and stores information about:'


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RIP-278

Add the missing apostrophe and remove unnecessary i18n for a full-stop. This
removes extra whitespace after link to ICO website.