### PR TITLE
RIP-291 Update grid ref help text

### DIFF
--- a/app/views/flood_risk_engine/enrollments/steps/_grid_reference.html.erb
+++ b/app/views/flood_risk_engine/enrollments/steps/_grid_reference.html.erb
@@ -26,7 +26,7 @@
       <p>
         <%=
           t(".details.tool_text", link: link_to( t(".details.tool_link"),
-                                                 "https://www.ordnancesurvey.co.uk/osmaps/",
+                                                 "http://gridreferencefinder.com/",
                                                  rel: "external", target: "_blank")
           ).html_safe
         %>
@@ -37,11 +37,9 @@
         </li>
         <li>
           <%= t(".details.bullet2") %>
-          <br/>
-          <%= t(".details.bullet3") %>
         </li>
         <li>
-          <%= t(".details.bullet4") %>
+          <%= t(".details.bullet3") %>
         </li>
       </ul>
     </div>

--- a/config/locales/flood_risk_engine/enrollments/steps/_grid_reference.en.yml
+++ b/config/locales/flood_risk_engine/enrollments/steps/_grid_reference.en.yml
@@ -25,11 +25,10 @@ en:
           details:
             summary: Help finding a grid reference
             tool_text: Use the free %{link}
-            tool_link:  Ordnance Survey online map (opens new window).
-            bullet1:  Search for a place and zoom in.
-            bullet2:  Right-click to drop a pin and see the grid reference.
-            bullet3:  Or select ‘Grid Ref' at the top and drag your location under the centre cross.
-            bullet4:  Select the grid reference then copy using Ctrl-C or Command-C keys.
+            tool_link: UK Grid Reference Finder (opens new window).
+            bullet1:  Search for the location or postcode on the right of the page.
+            bullet2:  Right-click to display the grid reference.
+            bullet3:  Select the grid reference then copy and paste back on this page.
           errors:
             grid_reference:
               invalid: "Enter the grid reference in this format: ST 58132 72695"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RIP-291

Updates the link to the grid reference tool to switch from using Ordnance Survey to using http://gridreferencefinder.com.

Updates instructions with text from:
http://river-permissions2.herokuapp.com/version_4/location/grid_reference