### PR TITLE
Add enrollment.submitted? and enrollment_exemption.status_one_of?

### DIFF
--- a/app/models/flood_risk_engine/enrollment.rb
+++ b/app/models/flood_risk_engine/enrollment.rb
@@ -34,17 +34,14 @@ module FloodRiskEngine
 
     has_one :address_search
 
-    serialize :step_history, Array
-
     before_validation :preserve_current_step
+    after_create :generate_and_save_reference_number
 
     # Have to use `validate` as `validates` is called on page load, before
     # the state machine class can be switched, and therefore is always run on the
     # default state machine. 'validate' calls the method on the instance so
     # can be run after the state machine class has been changed
     validate :step_defined_in_state_machines
-
-    after_create :generate_and_save_reference_number
 
     def to_param
       token
@@ -71,6 +68,10 @@ module FloodRiskEngine
     def submit
       return if submitted_at.present?
       self.submitted_at = Time.zone.now
+    end
+
+    def submitted?
+      submitted_at?
     end
 
     private

--- a/app/models/flood_risk_engine/enrollment_exemption.rb
+++ b/app/models/flood_risk_engine/enrollment_exemption.rb
@@ -40,5 +40,9 @@ module FloodRiskEngine
       latest_decision.last
     end
 
+    def status_one_of?(*statuses)
+      statuses.collect(&:to_s).include? status
+    end
+
   end
 end

--- a/spec/models/flood_risk_engine/enrollment_exemption_spec.rb
+++ b/spec/models/flood_risk_engine/enrollment_exemption_spec.rb
@@ -2,6 +2,9 @@ require "rails_helper"
 
 module FloodRiskEngine
   RSpec.describe EnrollmentExemption, type: :model do
+    let(:enrollment_exemption) { FactoryGirl.create(:enrollment_exemption) }
+    let(:status) { enrollment_exemption.status }
+
     it { is_expected.to be_valid }
     it { is_expected.to respond_to(:expires_at) }
     it { is_expected.to respond_to(:valid_from) }
@@ -42,6 +45,20 @@ module FloodRiskEngine
       end
       it "returns false if the collection does not include a long dredging exemption" do
         expect(described_class.include_long_dredging?).to be_falsey
+      end
+    end
+
+    describe "#status_one_of?" do
+      it "should return true if state is passed in" do
+        expect(enrollment_exemption.status_one_of?(status)).to eq(true)
+      end
+
+      it "should return true if state is passed in as one of many" do
+        expect(enrollment_exemption.status_one_of?(status, :foo, :bar)).to eq(true)
+      end
+
+      it "should return false if state is not passed in" do
+        expect(enrollment_exemption.status_one_of?(:foo, :bar)).to eq(false)
       end
     end
   end

--- a/spec/models/flood_risk_engine/enrollment_spec.rb
+++ b/spec/models/flood_risk_engine/enrollment_spec.rb
@@ -76,5 +76,19 @@ module FloodRiskEngine
         expect(enrollment.reference_number).to eq expected_reference_number
       end
     end
+
+    describe "#submitted?" do
+      it "should return false" do
+        expect(enrollment.submitted?).to eq(false)
+      end
+
+      context "after `submit` called" do
+        before { enrollment.submit }
+
+        it "should return true" do
+          expect(enrollment.submitted?).to eq(true)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Provides a better way of determining when an enrollment has been submitted, and matching enrollment exemption status with a set of alternatives.

Also some tidying up (see comments below)