### PR TITLE
Database fields to hold accept reject decision data

### DIFF
--- a/app/models/flood_risk_engine/enrollment_exemption.rb
+++ b/app/models/flood_risk_engine/enrollment_exemption.rb
@@ -20,30 +20,6 @@ module FloodRiskEngine
       includes(:exemption).where(flood_risk_engine_exemptions: { code: Exemption::LONG_DREDGING_CODES }).any?
     end
 
-    def accept_reject_decision_user
-      User.find_by_id(accept_reject_decision_user_id).try(:email)
-    end
-
-    def latest_comment_at_and_user_id
-      comments.order(:created_at).pluck(:created_at, :user_id).last
-    end
-
-    def decision_at_and_user
-      return [nil, nil] if comments.empty?
-      latest = latest_comment_at_and_user_id
-      [latest.first, User.find(latest.last).try(:email)]
-    end
-
-    def decision_at
-      return if comments.empty?
-      latest_comment_at_and_user_id.first
-    end
-
-    def decision_user_id
-      return if comments.empty?
-      latest_comment_at_and_user_id.last
-    end
-
     def status_one_of?(*statuses)
       statuses.collect(&:to_s).include? status
     end

--- a/app/models/flood_risk_engine/enrollment_exemption.rb
+++ b/app/models/flood_risk_engine/enrollment_exemption.rb
@@ -20,24 +20,28 @@ module FloodRiskEngine
       includes(:exemption).where(flood_risk_engine_exemptions: { code: Exemption::LONG_DREDGING_CODES }).any?
     end
 
-    def latest_decision
+    def accept_reject_decision_user
+      User.find_by_id(accept_reject_decision_user_id).try(:email)
+    end
+
+    def latest_comment_at_and_user_id
       comments.order(:created_at).pluck(:created_at, :user_id).last
     end
 
     def decision_at_and_user
       return [nil, nil] if comments.empty?
-      latest = latest_decision
+      latest = latest_comment_at_and_user_id
       [latest.first, User.find(latest.last).try(:email)]
     end
 
     def decision_at
       return if comments.empty?
-      latest_decision.first
+      latest_comment_at_and_user_id.first
     end
 
     def decision_user_id
       return if comments.empty?
-      latest_decision.last
+      latest_comment_at_and_user_id.last
     end
 
     def status_one_of?(*statuses)

--- a/db/migrate/20160701153812_add_accept_reject_decision_data.rb
+++ b/db/migrate/20160701153812_add_accept_reject_decision_data.rb
@@ -1,0 +1,8 @@
+class AddAcceptRejectDecisionData < ActiveRecord::Migration
+
+  def change
+    add_column :flood_risk_engine_enrollments_exemptions, :accept_reject_decision_user_id, :integer, index: true
+    add_column :flood_risk_engine_enrollments_exemptions, :accept_reject_decision_at, :datetime, index: true
+  end
+
+end

--- a/spec/models/flood_risk_engine/enrollment_exemption_spec.rb
+++ b/spec/models/flood_risk_engine/enrollment_exemption_spec.rb
@@ -30,8 +30,8 @@ module FloodRiskEngine
         ee.comments << comments
         sorted = comments.sort_by(&:created_at)
 
-        expect(ee.latest_decision.first.to_date).to eq sorted.last.created_at.to_date
-        expect(ee.latest_decision.last).to eq sorted.last.user_id
+        expect(ee.latest_comment_at_and_user_id.first.to_date).to eq sorted.last.created_at.to_date
+        expect(ee.latest_comment_at_and_user_id.last).to eq sorted.last.user_id
       end
     end
 

--- a/spec/models/flood_risk_engine/enrollment_exemption_spec.rb
+++ b/spec/models/flood_risk_engine/enrollment_exemption_spec.rb
@@ -16,25 +16,6 @@ module FloodRiskEngine
       end
     end
 
-    describe "comments" do
-      let(:ee) { FactoryGirl.create(:enrollment_exemption) }
-
-      it "returns nil  when no comments" do
-        expect(ee.decision_at_and_user).to eq [nil, nil]
-        expect(ee.decision_at).to eq nil
-        expect(ee.decision_user_id).to eq nil
-      end
-
-      it "returns latest decision_at and user id" do
-        comments = build_list(:comment, 6, :with_user_id)
-        ee.comments << comments
-        sorted = comments.sort_by(&:created_at)
-
-        expect(ee.latest_comment_at_and_user_id.first.to_date).to eq sorted.last.created_at.to_date
-        expect(ee.latest_comment_at_and_user_id.last).to eq sorted.last.user_id
-      end
-    end
-
     describe ".include_long_dredging?" do
       before(:each) { FactoryGirl.create(:enrollment_exemption) }
       it "returns true if the collection includes a long dredging exemption" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RIP-247

Clarity from NCCC :

· Decision user – This will be the person that has screened the registration and made the decision as to whether accept or reject.

· Decision date – this is the date we accept or reject the registration.

We need the decision date aswell as the submitted date to always remain the same, this is so we can compare how we are against our service level agreement. The decision maker we would want to show as the originally person that either accepted or rejected.