### PR TITLE
RIP-270 Allow ampersands in organisation name

### DIFF
--- a/app/forms/flood_risk_engine/steps/local_authority_form.rb
+++ b/app/forms/flood_risk_engine/steps/local_authority_form.rb
@@ -19,7 +19,10 @@ module FloodRiskEngine
 
       validates :name, presence: { message: t(".errors.name.blank") }
 
-      validates :name, 'flood_risk_engine/text_field_content': true, allow_blank: true
+      validates :name, 'EA::Validators::CompaniesHouseName': {
+        message: t(".errors.name.invalid"),
+        allow_blank: true
+      }
 
       validates :name, length: {
         maximum: LocalAuthorityForm.name_max_length,

--- a/app/forms/flood_risk_engine/steps/other_form.rb
+++ b/app/forms/flood_risk_engine/steps/other_form.rb
@@ -22,7 +22,8 @@ module FloodRiskEngine
         presence: {
           message: t(".errors.name.blank")
         },
-        "flood_risk_engine/text_field_content" => {
+        'EA::Validators::CompaniesHouseName': {
+          message: t(".errors.name.invalid"),
           allow_blank: true
         },
         length: {

--- a/config/locales/flood_risk_engine/enrollments/steps/_local_authority.en.yml
+++ b/config/locales/flood_risk_engine/enrollments/steps/_local_authority.en.yml
@@ -12,3 +12,4 @@ en:
             name:
              blank: Enter the name of the local authority or public body
              too_long: Check the name - it should have no more than %{max} characters
+             invalid: 'The local authority name cannot contain any of these characters: ^ | _ ~ ¬ or `'

--- a/config/locales/flood_risk_engine/enrollments/steps/_other.en.yml
+++ b/config/locales/flood_risk_engine/enrollments/steps/_other.en.yml
@@ -11,3 +11,4 @@ en:
             name:
              blank: Enter the name of the organisation
              too_long: Check the name - it should have no more than %{max} characters
+             invalid: 'The organisation name cannot contain any of these characters: ^ | _ ~ ¬ or `'

--- a/spec/controllers/flood_risk_engine/enrollments/steps_controller/local_authority_spec.rb
+++ b/spec/controllers/flood_risk_engine/enrollments/steps_controller/local_authority_spec.rb
@@ -34,7 +34,7 @@ module FloodRiskEngine
 
         context "with invalid params" do
           let(:invalid_attributes) do
-            { name: "12345 not a valid name **" }
+            { name: "12345 ^ not a valid name **" }
           end
 
           it "assigns the enrollment as @enrollment" do
@@ -57,7 +57,7 @@ module FloodRiskEngine
           it "displays error on rendering show" do
             params = { id: step, enrollment_id: enrollment, check_for_error: true }
             session = { error_params: { step => invalid_attributes } }
-            expected_error = I18n.t("flood_risk_engine.validation_errors.name.invalid")
+            expected_error = I18n.t("flood_risk_engine.enrollments.steps.local_authority.errors.name.invalid")
 
             get(:show, params, session)
             expect(response.body).to have_tag :a, text: expected_error

--- a/spec/forms/flood_risk_engine/steps/local_authority_form_spec.rb
+++ b/spec/forms/flood_risk_engine/steps/local_authority_form_spec.rb
@@ -25,7 +25,7 @@ module FloodRiskEngine
       describe "#save" do
         it "saves the name of the local authority when name supplied" do
           expect(enrollment).to receive(:save).and_return(true)
-          params = { "#{form.params_key}": { name: "Bodge It and Scarper Ltd" } }
+          params = { form.params_key => { name: "Bodge It and Scarper Ltd" } }
 
           expect(subject.redirect?).to eq(false)
 
@@ -36,24 +36,30 @@ module FloodRiskEngine
         end
 
         it "does not validate when no name supplied" do
-          params = { "#{form.params_key}": { name: "" } }
+          params = { form.params_key => { name: "" } }
 
           expect(form.validate(params)).to eq false
           expect(subject.errors.messages[:name])
             .to eq([I18n.t("#{LocalAuthorityForm.locale_key}.errors.name.blank")])
         end
 
+        it "Validates when name has an ampersand" do
+          params = { form.params_key => { name: "Ruby & White" } }
+
+          expect(form.validate(params)).to eq true
+        end
+
         it "does not validate when name with unacceptable chars" do
-          params = { "#{form.params_key}": { name: "bristol *& " } }
+          params = { form.params_key => { name: "bristol ^" } }
 
           expect(form.validate(params)).to eq false
           expect(subject.errors.messages[:name])
-            .to eq([I18n.t("flood_risk_engine.validation_errors.name.invalid")])
+            .to eq([I18n.t("#{LocalAuthorityForm.locale_key}.errors.name.invalid")])
         end
 
         it "does not validate when name supplied is too long" do
           name = "this will is will blow" + "a" * LocalAuthorityForm.name_max_length
-          params = { "#{form.params_key}": { name: name } }
+          params = { form.params_key => { name: name } }
 
           expect(form.validate(params)).to eq false
           expect(

--- a/spec/forms/flood_risk_engine/steps/other_form_spec.rb
+++ b/spec/forms/flood_risk_engine/steps/other_form_spec.rb
@@ -41,12 +41,18 @@ module FloodRiskEngine
             .to eq([I18n.t(".errors.name.blank", scope: i18n_scope)])
         end
 
+        it "validates when name has an ampersand" do
+          params = { form.params_key => { name: "Ruby & White" } }
+
+          expect(form.validate(params)).to eq true
+        end
+
         it "does not validate when name with unacceptable chars" do
-          params = { form.params_key => { name: "bristol *& " } }
+          params = { form.params_key => { name: "bristol ^ " } }
 
           expect(form.validate(params)).to eq(false)
           expect(subject.errors.messages[:name])
-            .to eq([I18n.t("flood_risk_engine.validation_errors.name.invalid")])
+            .to eq([I18n.t("#{OtherForm.locale_key}.errors.name.invalid")])
         end
 
         it "does not validate when name supplied is too long" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RIP-270

"Canal & River Trust" is correct but generates an error. Need & to be allowed.
Applied this rule to Partnerships and Local Authorities in this commit.