### PR TITLE
RIP-315 Confirmation page should show two emails

### DIFF
--- a/app/forms/flood_risk_engine/steps/confirmation_form.rb
+++ b/app/forms/flood_risk_engine/steps/confirmation_form.rb
@@ -19,12 +19,11 @@ module FloodRiskEngine
       property :email, virtual: true
 
       def email
-        # If we need to display multiple emails e.g contact and email_someone_else then this works
-        # emails = [enrollment.correspondence_contact.email_address]
-        # emails.map(&:downcase).uniq.to_sentence
-
-        # For now
-        enrollment.correspondence_contact.email_address
+        emails = [
+          enrollment.correspondence_contact.email_address,
+          enrollment.secondary_contact.try(:email_address)
+        ]
+        emails.delete_if(&:blank?).map(&:downcase).uniq.to_sentence
       end
 
       def no_header_in_show

--- a/spec/forms/flood_risk_engine/steps/confirmation_form_spec.rb
+++ b/spec/forms/flood_risk_engine/steps/confirmation_form_spec.rb
@@ -38,6 +38,26 @@ module FloodRiskEngine
           expect(form.save).to eq true
         end
       end
+
+      describe "#email" do
+        context "there is no enrollment secondary contact" do
+          it "returns a single email address" do
+            expect(form.email).to eq(enrollment.correspondence_contact.email_address)
+          end
+        end
+        context "there is an enrollment secondary contact" do
+          let(:enrollment) { create(:page_confirmation, :with_secondary_contact) }
+          it "returns two email addresses in a sentence" do
+            expected_sentence = [
+              enrollment.correspondence_contact.email_address,
+              " and ",
+              enrollment.secondary_contact.email_address
+            ].join
+
+            expect(form.email).to eq(expected_sentence)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RIP-315

If a secondary contact is present display that email address on the
confirmation page.