### PR TITLE
Update error messages and link text for manual address entry

### DIFF
--- a/config/locales/flood_risk_engine/enrollments/addresses.en.yml
+++ b/config/locales/flood_risk_engine/enrollments/addresses.en.yml
@@ -40,4 +40,4 @@ en:
           city:
             blank: Enter a town or city
             too_long: The town or city must be no longer than %{max} characters
-        manual_entry: "I can’t find the address in the list"
+        manual_entry: Enter address manually

--- a/config/locales/flood_risk_engine/validation_errors.en.yml
+++ b/config/locales/flood_risk_engine/validation_errors.en.yml
@@ -13,8 +13,9 @@ en:
         blank: Enter a postcode
         enter_a_valid_postcode: Enter a valid UK postcode
         no_addresses_found: We can’t find any addresses for that postcode.
-          Please check the postcode or enter the address manually
-        service_unavailable: Our address finder is not working. Please enter the address below.
+          Please check the postcode or select the 'Enter address manually' link.
+        service_unavailable: Our address finder is not working. Please select the
+          'Enter address manually' link and enter the address yourself.
       uprn:
         blank: Please select an address
         format: UPRN must be a number

--- a/spec/controllers/flood_risk_engine/enrollments/partners_controller_spec.rb
+++ b/spec/controllers/flood_risk_engine/enrollments/partners_controller_spec.rb
@@ -30,7 +30,9 @@ module FloodRiskEngine
         end
 
         it "should display partner's name" do
-          expect(response.body).to match(contact.full_name)
+          # Splitting to remove issues with names like "O'Connor" being
+          # escaped in erb to "O&#39;Conner".
+          expect(response.body).to match(contact.full_name.split(/\W/).last)
         end
       end
 


### PR DESCRIPTION
See [RIP-310](https://eaflood.atlassian.net/browse/RIP-310) and [RIP-307](**https://eaflood.atlassian.net/browse/RIP-307)

Make it more obvious that user needs to click on link to proceed.