### PR TITLE
RIP-210 Fix multiple partner search results

### DIFF
--- a/app/models/flood_risk_engine/contact.rb
+++ b/app/models/flood_risk_engine/contact.rb
@@ -20,5 +20,10 @@ module FloodRiskEngine
       na Mr Mrs Miss Ms Dr Rev Sir Lady Lord
       Captain Major Professor Dame Colonel
     )
+
+    after_save do
+      organisation.try(:update_searchable_content)
+    end
+
   end
 end

--- a/app/models/flood_risk_engine/partner.rb
+++ b/app/models/flood_risk_engine/partner.rb
@@ -4,5 +4,9 @@ module FloodRiskEngine
     belongs_to :contact
 
     delegate :full_name, :address, to: :contact
+
+    after_save do
+      organisation.try(:update_searchable_content)
+    end
   end
 end

--- a/db/migrate/20160712104613_add_searchable_content_to_organisations.rb
+++ b/db/migrate/20160712104613_add_searchable_content_to_organisations.rb
@@ -1,0 +1,6 @@
+class AddSearchableContentToOrganisations < ActiveRecord::Migration
+  def change
+    add_column :flood_risk_engine_organisations, :searchable_content, :text
+    add_index :flood_risk_engine_organisations, :searchable_content
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160711111533) do
+ActiveRecord::Schema.define(version: 20160712104613) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -88,9 +88,8 @@ ActiveRecord::Schema.define(version: 20160711111533) do
     t.integer  "organisation_id"
     t.string   "step",                      limit: 50
     t.integer  "correspondence_contact_id"
-    t.integer  "secondary_contact_id"
     t.string   "token"
-    t.boolean  "in_review"
+    t.integer  "secondary_contact_id"
     t.datetime "submitted_at"
     t.integer  "reference_number_id"
   end
@@ -148,11 +147,13 @@ ActiveRecord::Schema.define(version: 20160711111533) do
     t.datetime "updated_at",                     null: false
     t.integer  "org_type"
     t.string   "registration_number", limit: 12
+    t.text     "searchable_content"
   end
 
   add_index "flood_risk_engine_organisations", ["contact_id"], name: "index_flood_risk_engine_organisations_on_contact_id", using: :btree
   add_index "flood_risk_engine_organisations", ["org_type"], name: "index_flood_risk_engine_organisations_on_org_type", using: :btree
   add_index "flood_risk_engine_organisations", ["registration_number"], name: "index_flood_risk_engine_organisations_on_registration_number", using: :btree
+  add_index "flood_risk_engine_organisations", ["searchable_content"], name: "index_flood_risk_engine_organisations_on_searchable_content", using: :btree
 
   create_table "flood_risk_engine_partners", force: :cascade do |t|
     t.integer  "organisation_id"

--- a/spec/factories/partners.rb
+++ b/spec/factories/partners.rb
@@ -1,4 +1,28 @@
 FactoryGirl.define do
   factory :partner, class: "FloodRiskEngine::Partner" do
   end
+
+  factory :partner_address, class: "FloodRiskEngine::Address" do
+    premises            { Faker::Address.building_number }
+    street_address      { Faker::Address.street_address }
+    locality            { Faker::Address.street_address }
+    city                { Faker::Address.city }
+    postcode            { generate :uk_post_code }
+  end
+
+  factory :partner_contact, class: "FloodRiskEngine::Contact" do
+    title 1
+    full_name { Faker::Name.name }
+    suffix Faker::Name.suffix
+    date_of_birth { rand(20..50).years.ago }
+    position { Faker::Company.profession }
+    email_address { generate(:random_email) }
+    telephone_number { Faker::PhoneNumber.phone_number }
+
+    after(:create) { |object| object.address = create :partner_address }
+  end
+
+  factory :partner_with_contact, class: "FloodRiskEngine::Partner" do
+    association :contact, factory: :partner_contact
+  end
 end

--- a/spec/forms/flood_risk_engine/steps/partnership_address_form_spec.rb
+++ b/spec/forms/flood_risk_engine/steps/partnership_address_form_spec.rb
@@ -69,7 +69,7 @@ module FloodRiskEngine
 
       describe "#partner" do
         it "should match the last partner" do
-          expect(form.partner).to eq(enrollment.partners.last)
+          expect(form.partner).to eq(enrollment.reload.partners.last)
         end
 
         context "when more than one partner present" do

--- a/spec/forms/flood_risk_engine/steps/partnership_detail_form_spec.rb
+++ b/spec/forms/flood_risk_engine/steps/partnership_detail_form_spec.rb
@@ -43,7 +43,7 @@ module FloodRiskEngine
           end
 
           it "should remove the incomplete partner" do
-            expect { described_class.new(enrollment) }.to change(Partner, :count).by(-1)
+            expect { described_class.new(enrollment.reload) }.to change(Partner, :count).by(-1)
             expect(enrollment.reload.partners).to eq([partner])
           end
         end

--- a/spec/models/flood_risk_engine/organisation_spec.rb
+++ b/spec/models/flood_risk_engine/organisation_spec.rb
@@ -6,5 +6,34 @@ module FloodRiskEngine
     it { is_expected.to have_one(:enrollment).dependent(:restrict_with_exception) }
     it { is_expected.to have_one(:primary_address).dependent(:restrict_with_exception) }
     it { is_expected.to have_many(:partners) }
+
+    let(:organisation) { create(:organisation) }
+
+    describe "#contact_search_string" do
+      context "isn't a partnership" do
+        let(:organisation) { create(:organisation) }
+        context "it has no contact" do
+          it { expect(organisation.send(:contact_search_string)).to eq("") }
+        end
+        context "it has a contact" do
+          it "returns a string containing the contact name" do
+            organisation.contact = create(:contact)
+            expect(organisation.send(:contact_search_string)).to eq(organisation.contact.full_name)
+          end
+        end
+      end
+      context "is a partnership" do
+        let(:organisation) { create(:organisation, org_type: :partnership) }
+        it "returns a string containing the partners names" do
+          partner1 = create(:partner_with_contact)
+          partner2 = create(:partner_with_contact)
+          organisation.partners << [partner1, partner2]
+          expect(organisation.send(:contact_search_string)).to eq("#{partner1.full_name} #{partner2.full_name}")
+        end
+        it "returns an empty string when there's no partners" do
+          expect(organisation.send(:contact_search_string)).to eq("")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RIP-210

Put in a solution to the multiple partner search result issue by
creating a search content column on the organisation model.

Then we can search that column in the BO without using an outer join
which was returning multiple enrolments.