### PR TITLE
Fix missing 'Outside England' area

### DIFF
--- a/app/jobs/flood_risk_engine/update_water_boundary_area_job.rb
+++ b/app/jobs/flood_risk_engine/update_water_boundary_area_job.rb
@@ -34,7 +34,7 @@ module FloodRiskEngine
     end
 
     def inside_england?(api_result)
-      api_result.key?(:long_name)
+      api_result[:long_name].present?
     end
   end
 end

--- a/spec/jobs/flood_risk_engine/update_water_boundary_area_spec.rb
+++ b/spec/jobs/flood_risk_engine/update_water_boundary_area_spec.rb
@@ -45,9 +45,14 @@ module FloodRiskEngine
           location = FactoryGirl.build_stubbed(:location,
                                                easting: "438920",
                                                northing: "1164159")
+          area_hash_from_api = { area_id: "",
+                                 code: "",
+                                 area_name: "",
+                                 short_name: "",
+                                 long_name: "" }
           expect(EA::AreaLookup)
             .to receive(:find_by_coordinates)
-            .and_return({})
+            .and_return(area_hash_from_api)
 
           described_class.perform_now(location)
 


### PR DESCRIPTION
A previous refactor of area lookup result handling
introduced this error.