### PR TITLE
RIP-321 Update page titles

### DIFF
--- a/app/helpers/flood_risk_engine/application_helper.rb
+++ b/app/helpers/flood_risk_engine/application_helper.rb
@@ -55,7 +55,7 @@ module FloodRiskEngine
       stripped_title = title.gsub(/’/, %('))
 
       if content_for? :page_title
-        content_for :page_title, " | #{stripped_title}"
+        content_for :page_title, " - #{stripped_title} - GOV.UK"
       else
         content_for :page_title, stripped_title.to_s
       end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RIP-321

Add GOV.UK and hyphens instead of pipes to the page title