### PR TITLE
Update version to 1.0.0 ready for release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    flood_risk_engine (0.0.1)
+    flood_risk_engine (1.0.0)
       activerecord-session_store (~> 1.0)
       airbrake (~> 5.3.0)
       airbrake-ruby (~> 1.3.2)

--- a/lib/flood_risk_engine/version.rb
+++ b/lib/flood_risk_engine/version.rb
@@ -1,3 +1,3 @@
 module FloodRiskEngine
-  VERSION = "0.0.1".freeze
+  VERSION = "1.0.0".freeze
 end


### PR DESCRIPTION
As part of releasing a new version of the Flood Risk Activity Exemptions service (FRAE) we are also updating and tagging the engine it uses so we have a clear understanding of what is being used in production.