### PR TITLE
ITSM-1179689 Fix issue with firefox details / summary function

### DIFF
--- a/app/views/flood_risk_engine/enrollments/steps/_grid_reference.html.erb
+++ b/app/views/flood_risk_engine/enrollments/steps/_grid_reference.html.erb
@@ -20,7 +20,7 @@
     %>
   <% end %>
 
-  <details style="padding-bottom: 18px;" id="ngr_help">
+  <details style="padding-bottom: 18px; clear: both;" id="ngr_help">
     <summary><span class="summary"><%= t(".details.summary") %></span></summary>
     <div class="panel panel-border-narrow">
       <p>


### PR DESCRIPTION
On the grid reference page, using Firefox, it is not possible to enter a NGR because clicking the input box expands or contracts the summary beneath. Clearing the floated element above fixes this.