### PR TITLE
Update version to 1.0.1 ready for release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    flood_risk_engine (1.0.0)
+    flood_risk_engine (1.0.1)
       activerecord-session_store (~> 1.0)
       airbrake (~> 5.3.0)
       airbrake-ruby (~> 1.3.2)
@@ -113,7 +113,7 @@ GEM
       representable (>= 2.4.0, <= 3.1.0)
       uber
     docile (1.1.5)
-    domain_name (0.5.20160615)
+    domain_name (0.5.20161129)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.1.1)
     dotenv-rails (2.1.1)
@@ -163,11 +163,11 @@ GEM
     hashdiff (0.3.0)
     high_voltage (3.0.0)
     htmlentities (4.3.4)
-    http-cookie (1.0.2)
+    http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.7.0)
     ice_nine (0.11.2)
-    jquery-rails (4.1.1)
+    jquery-rails (4.2.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
@@ -202,7 +202,7 @@ GEM
     parser (2.3.3.0)
       ast (~> 2.2)
     pg (0.18.4)
-    phonelib (0.6.2)
+    phonelib (0.6.8)
     poltergeist (1.9.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -253,9 +253,9 @@ GEM
       representable (>= 2.4.0, < 3.1.0)
       uber (~> 0.0.11)
     reform-rails (0.1.0)
-    representable (3.0.0)
+    representable (3.0.2)
       declarative (~> 0.0.5)
-      uber (~> 0.0.15)
+      uber (>= 0.0.15, < 0.2.0)
     rest-client (2.0.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
@@ -324,7 +324,7 @@ GEM
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uber (0.0.15)
-    uk_postcode (2.1.0)
+    uk_postcode (2.1.1)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.2)
@@ -375,4 +375,4 @@ DEPENDENCIES
   webmock (~> 1.24)
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/lib/flood_risk_engine/version.rb
+++ b/lib/flood_risk_engine/version.rb
@@ -1,3 +1,3 @@
 module FloodRiskEngine
-  VERSION = "1.0.0".freeze
+  VERSION = "1.0.1".freeze
 end


### PR DESCRIPTION
As part of releasing a new version of the Flood risk activity exemptions registration service we are also updating and tagging the engine it uses so we have a clear understanding of what is being used in production.