### PR TITLE
Add OS places notice and T&C's to service

### DIFF
--- a/app/forms/flood_risk_engine/steps/base_address_search_form.rb
+++ b/app/forms/flood_risk_engine/steps/base_address_search_form.rb
@@ -51,6 +51,17 @@ module FloodRiskEngine
         :correspondence_contact_name
       end
 
+      # We are required to display a notice regarding use of OS places data in
+      # postcode lookup pages. However we wish to display this below the
+      # continue button, which means those pages have to take control of where
+      # it is positioned. To do this we override the show_continue_button? and
+      # return false, so that
+      # app/views/flood_risk_engine/enrollments/steps/show.html.erb knows not
+      # to take control for showing the button.
+      def show_continue_button?
+        false
+      end
+
     end
 
   end

--- a/app/views/flood_risk_engine/enrollments/steps/_individual_postcode.html.erb
+++ b/app/views/flood_risk_engine/enrollments/steps/_individual_postcode.html.erb
@@ -2,5 +2,6 @@
             f: f,
             form: form,
             addressable: form.enrollment.organisation,
-            address_type: :primary )
+            address_type: :primary,
+            step: step )
 %>

--- a/app/views/flood_risk_engine/enrollments/steps/_limited_company_postcode.html.erb
+++ b/app/views/flood_risk_engine/enrollments/steps/_limited_company_postcode.html.erb
@@ -2,5 +2,6 @@
             f: f,
             form: form,
             addressable: form.enrollment.organisation,
-            address_type: :primary )
+            address_type: :primary,
+            step: step )
 %>

--- a/app/views/flood_risk_engine/enrollments/steps/_limited_liability_partnership_postcode.html.erb
+++ b/app/views/flood_risk_engine/enrollments/steps/_limited_liability_partnership_postcode.html.erb
@@ -2,5 +2,6 @@
             f: f,
             form: form,
             addressable: form.enrollment.organisation,
-            address_type: :primary )
+            address_type: :primary,
+            step: step )
 %>

--- a/app/views/flood_risk_engine/enrollments/steps/_local_authority_postcode.html.erb
+++ b/app/views/flood_risk_engine/enrollments/steps/_local_authority_postcode.html.erb
@@ -2,5 +2,6 @@
             f: f,
             form: form,
             addressable: form.enrollment.organisation,
-            address_type: :primary )
+            address_type: :primary,
+            step: step )
 %>

--- a/app/views/flood_risk_engine/enrollments/steps/_other_postcode.html.erb
+++ b/app/views/flood_risk_engine/enrollments/steps/_other_postcode.html.erb
@@ -1,7 +1,7 @@
 <%= render( "flood_risk_engine/shared/postcode",
-    f: f,
-    form: form,
-    addressable: form.enrollment.organisation,
-    address_type: :primary
-  )
+            f: f,
+            form: form,
+            addressable: form.enrollment.organisation,
+            address_type: :primary,
+            step: step )
 %>

--- a/app/views/flood_risk_engine/enrollments/steps/_partnership_postcode.html.erb
+++ b/app/views/flood_risk_engine/enrollments/steps/_partnership_postcode.html.erb
@@ -9,9 +9,9 @@
 %>
 
 <%= render( "flood_risk_engine/shared/postcode",
-    f: f,
-    form: form,
-    addressable: form.partner.contact,
-    address_type: :partner
-  )
+            f: f,
+            form: form,
+            addressable: form.partner.contact,
+            address_type: :partner,
+            step: step )
 %>

--- a/app/views/flood_risk_engine/shared/_postcode.html.erb
+++ b/app/views/flood_risk_engine/shared/_postcode.html.erb
@@ -33,12 +33,12 @@
 <p class="text font-xsmall" id="os-notice">
   <%=
     t(
-      ".os_notice.text",
+      ".os_notice.text_html",
       link: link_to(
         t(".os_notice.url_text"),
         enrollment_page_path(form.enrollment, id: "os_places_terms"),
         target: "_blank"
       )
-    ).html_safe
+    )
   %>
 </p>

--- a/app/views/flood_risk_engine/shared/_postcode.html.erb
+++ b/app/views/flood_risk_engine/shared/_postcode.html.erb
@@ -22,5 +22,23 @@
       %>
     </p>
   <% end  %>
-
+  <p class="text" id="os-notice">
+    <%=
+      t(
+        ".os_notice.text",
+        link1: link_to(
+          t(".os_notice.url1_text"),
+          t('.os_notice.url1'),
+          rel: "external",
+          target: "_blank"
+        ),
+        link2: link_to(
+          t(".os_notice.url2_text"),
+          enrollment_page_path(form.enrollment, id: "os_places_terms"),
+          rel: "external",
+          target: "_blank"
+        )
+      ).html_safe
+    %>
+  </p>
 </fieldset>

--- a/app/views/flood_risk_engine/shared/_postcode.html.erb
+++ b/app/views/flood_risk_engine/shared/_postcode.html.erb
@@ -22,23 +22,23 @@
       %>
     </p>
   <% end  %>
-  <p class="text" id="os-notice">
-    <%=
-      t(
-        ".os_notice.text",
-        link1: link_to(
-          t(".os_notice.url1_text"),
-          t('.os_notice.url1'),
-          rel: "external",
-          target: "_blank"
-        ),
-        link2: link_to(
-          t(".os_notice.url2_text"),
-          enrollment_page_path(form.enrollment, id: "os_places_terms"),
-          rel: "external",
-          target: "_blank"
-        )
-      ).html_safe
-    %>
-  </p>
+
 </fieldset>
+
+<div class="form-group">
+  <%= f.submit(step_t(step, ".continue",  default: t("global.continue")), class: "button") %>
+</div>
+&nbsp;
+<hr />
+<p class="text font-xsmall" id="os-notice">
+  <%=
+    t(
+      ".os_notice.text",
+      link: link_to(
+        t(".os_notice.url_text"),
+        enrollment_page_path(form.enrollment, id: "os_places_terms"),
+        target: "_blank"
+      )
+    ).html_safe
+  %>
+</p>

--- a/app/views/pages/os_places_terms.html.erb
+++ b/app/views/pages/os_places_terms.html.erb
@@ -7,7 +7,7 @@
       </h1>
     </header>
 
-    <p class="text"><%= t(".para1_text").html_safe %></p>
+    <p class="text"><%= t(".para1_text_html") %></p>
 
     <p class="text"><%= t('.para2_text') %></p>
 

--- a/app/views/pages/os_places_terms.html.erb
+++ b/app/views/pages/os_places_terms.html.erb
@@ -1,0 +1,38 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+
+    <header class="text">
+      <h1 class="form-title heading-large" id="groupLabel">
+        <%= page_title t('.heading_h1') %>
+      </h1>
+    </header>
+
+    <p class="text">
+      <%=
+        t(
+          ".para1_text",
+          link: link_to(
+            t(".url_text"),
+            t('.url'),
+            rel: "external",
+            target: "_blank")
+        ).html_safe
+      %>
+    </p>
+
+    <p class="text"><%= t('.para2_text') %></p>
+
+    <p class="lede text"><%= t('.para3_text') %></p>
+
+    <ol class="list list-number text">
+      <li><%= t('.list_item1') %></li>
+      <li><%= t('.list_item2') %></li>
+      <li><%= t('.list_item3') %></li>
+    </ol>
+
+    <div class="panel panel-border-wide">
+      <p class="text"><%= t('.para4_text') %></p>
+    </div>
+
+  </div>
+</div>

--- a/app/views/pages/os_places_terms.html.erb
+++ b/app/views/pages/os_places_terms.html.erb
@@ -7,22 +7,11 @@
       </h1>
     </header>
 
-    <p class="text">
-      <%=
-        t(
-          ".para1_text",
-          link: link_to(
-            t(".url_text"),
-            t('.url'),
-            rel: "external",
-            target: "_blank")
-        ).html_safe
-      %>
-    </p>
+    <p class="text"><%= t(".para1_text").html_safe %></p>
 
     <p class="text"><%= t('.para2_text') %></p>
 
-    <p class="lede text"><%= t('.para3_text') %></p>
+    <h2 class="heading-medium"><%= t('.heading_h2') %></h2>
 
     <ol class="list list-number text">
       <li><%= t('.list_item1') %></li>
@@ -31,6 +20,7 @@
     </ol>
 
     <div class="panel panel-border-wide">
+      <p class="text"><%= t('.para3_text') %></p>
       <p class="text"><%= t('.para4_text') %></p>
     </div>
 

--- a/config/locales/flood_risk_engine/shared.en.yml
+++ b/config/locales/flood_risk_engine/shared.en.yml
@@ -34,6 +34,6 @@ en:
           individual_postcode:
              label: What's the address of the individual?
           os_notice:
-            text: |-
+            text_html: |-
               &copy; Crown copyright and database rights 2016 Ordnance Survey 100024198. Use of this addressing data is subject to the %{link}.
-            url_text: terms and conditions
+            url_text: terms and conditions (opens new window)

--- a/config/locales/flood_risk_engine/shared.en.yml
+++ b/config/locales/flood_risk_engine/shared.en.yml
@@ -35,7 +35,5 @@ en:
              label: What's the address of the individual?
           os_notice:
             text: |-
-              © Crown copyright and database rights 2016 %{link1} 100024198. Use of this addressing data is subject to the %{link2}.
-            url1: 'https://www.ordnancesurvey.co.uk/'
-            url1_text: OS (opens new window)
-            url2_text: terms and conditions (opens new window)
+              &copy; Crown copyright and database rights 2016 Ordnance Survey 100024198. Use of this addressing data is subject to the %{link}.
+            url_text: terms and conditions

--- a/config/locales/flood_risk_engine/shared.en.yml
+++ b/config/locales/flood_risk_engine/shared.en.yml
@@ -33,3 +33,9 @@ en:
           legend: UK postcode
           individual_postcode:
              label: What's the address of the individual?
+          os_notice:
+            text: |-
+              © Crown copyright and database rights 2016 %{link1} 100024198. Use of this addressing data is subject to the %{link2}.
+            url1: 'https://www.ordnancesurvey.co.uk/'
+            url1_text: OS (opens new window)
+            url2_text: terms and conditions (opens new window)

--- a/config/locales/pages/os_places_terms.en.yml
+++ b/config/locales/pages/os_places_terms.en.yml
@@ -9,7 +9,7 @@ en:
         non-commercial purposes for the period during which we make it available.
       list_item2: You are not permitted to copy, sub-license, distribute, sell or otherwise make available such data to third parties in any form.
       list_item3: Third party rights to enforce the terms of this licence shall be reserved to OS.
-      para1_text: |-
+      para1_text_html: |-
         Addressing information and mapping data from Ordnance Survey (OS) is &copy; Crown copyright and database rights 2016 OS 100024198.
       para2_text: |-
         Use of this data is subject to the following conditions by way of exception to the standard Open Government Licence (OGL) referred

--- a/config/locales/pages/os_places_terms.en.yml
+++ b/config/locales/pages/os_places_terms.en.yml
@@ -1,0 +1,21 @@
+---
+en:
+  pages:
+    os_places_terms:
+      heading_h1: Ordnance Survey terms and conditions
+      list_item1: You are granted a non-exclusive, royalty free revocable licence solely to view the licensed mapping and addressing data for non-commercial purposes for the period during which we make it available.
+      list_item2: You are not permitted to copy, sub-license, distribute, sell or otherwise make available such data to third parties in any form.
+      list_item3: Third party rights to enforce the terms of this licence shall be reserved to OS.
+      para1_text: |-
+        Addressing information and mapping data from Ordnance Survey is © Crown copyright and database rights 2016 %{link} 100024198.
+      para2_text: |-
+        Use of this data is subject to the following conditions by way of exception to the standard Open Government Licence referred
+        to at the foot of this page.
+      para3_text: Terms and Conditions
+      para4_text: |-
+        22 December 2016: Please note that addressing information and mapping data available from this web service was previously inadvertently
+        released without passing on these terms and conditions.  The previous reference to the OGL without these additional terms was an
+        omission, and you should note that you are only permitted to use such information for viewing for non-commercial purposes; you are
+        not permitted to copy, sub-license, distribute, sell or otherwise make available such data, or use it for any other purpose.
+      url: 'https://www.ordnancesurvey.co.uk/'
+      url_text: OS (opens new window)

--- a/config/locales/pages/os_places_terms.en.yml
+++ b/config/locales/pages/os_places_terms.en.yml
@@ -3,19 +3,21 @@ en:
   pages:
     os_places_terms:
       heading_h1: Ordnance Survey terms and conditions
-      list_item1: You are granted a non-exclusive, royalty free revocable licence solely to view the licensed mapping and addressing data for non-commercial purposes for the period during which we make it available.
+      heading_h2: Terms and conditions
+      list_item1: |-
+        You are granted a non-exclusive, royalty free revocable licence solely to view the licensed mapping and addressing data for
+        non-commercial purposes for the period during which we make it available.
       list_item2: You are not permitted to copy, sub-license, distribute, sell or otherwise make available such data to third parties in any form.
       list_item3: Third party rights to enforce the terms of this licence shall be reserved to OS.
       para1_text: |-
-        Addressing information and mapping data from Ordnance Survey is © Crown copyright and database rights 2016 %{link} 100024198.
+        Addressing information and mapping data from Ordnance Survey (OS) is &copy; Crown copyright and database rights 2016 OS 100024198.
       para2_text: |-
-        Use of this data is subject to the following conditions by way of exception to the standard Open Government Licence referred
+        Use of this data is subject to the following conditions by way of exception to the standard Open Government Licence (OGL) referred
         to at the foot of this page.
-      para3_text: Terms and Conditions
-      para4_text: |-
+      para3_text: |-
         22 December 2016: Please note that addressing information and mapping data available from this web service was previously inadvertently
-        released without passing on these terms and conditions.  The previous reference to the OGL without these additional terms was an
-        omission, and you should note that you are only permitted to use such information for viewing for non-commercial purposes; you are
-        not permitted to copy, sub-license, distribute, sell or otherwise make available such data, or use it for any other purpose.
-      url: 'https://www.ordnancesurvey.co.uk/'
-      url_text: OS (opens new window)
+        released without passing on these terms and conditions.
+      para4_text: |-
+        The previous reference to the OGL without these additional terms was an omission, and you should note that you are only permitted
+        to use such information for viewing for non-commercial purposes; you are not permitted to copy, sub-license, distribute, sell or
+        otherwise make available such data, or use it for any other purpose.

--- a/spec/controllers/flood_risk_engine/enrollments/pages_controller_spec.rb
+++ b/spec/controllers/flood_risk_engine/enrollments/pages_controller_spec.rb
@@ -23,5 +23,16 @@ module FloodRiskEngine
         expect(response.body).to_not include "translation missing:"
       end
     end
+
+    context "Given I'm on the local authority postcode page" do
+      let(:enrollment) { FactoryGirl.create(:page_local_authority_postcode) }
+
+      it "When I click the t&c's link Then the OS Places T&C's page will open in a new tab" do
+        get :show, id: "os_places_terms", enrollment_id: enrollment
+
+        expect(response.body).to have_text t("pages.os_places_terms.heading_h1")
+        expect(response.body).to_not include "translation missing:"
+      end
+    end
   end
 end

--- a/spec/controllers/flood_risk_engine/enrollments/steps_controller/postcodes_spec.rb
+++ b/spec/controllers/flood_risk_engine/enrollments/steps_controller/postcodes_spec.rb
@@ -37,6 +37,10 @@ module FloodRiskEngine
         expect(response.body).to have_selector("input[type=submit][value='Continue']")
       end
 
+      it "displays OS Places notice" do
+        expect(response.body).to have_selector("p#os-notice")
+      end
+
       let(:valid_attributes) { { local_authority_postcode: { postcode: "BS1 5AH" } } }
 
       let(:match_initial_url_step) { /You are being <a href=\"\S+local_authority_postcode/ }


### PR DESCRIPTION
It's been highlighted that the service is missing a required notice and link to T&C's related to using OS Places and its data within the service.

Specifically we have to add the notice and link on the page where postcode lookup is used. This changes updates the view with the notice text, and adds a new OS Places T&C's page which is accessed from a link in the notice.