### PR TITLE
Update version due to OS place T&C's change

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    flood_risk_engine (1.0.1)
+    flood_risk_engine (1.0.2)
       activerecord-session_store (~> 1.0)
       airbrake (~> 5.3.0)
       airbrake-ruby (~> 1.3.2)

--- a/lib/flood_risk_engine/version.rb
+++ b/lib/flood_risk_engine/version.rb
@@ -1,3 +1,3 @@
 module FloodRiskEngine
-  VERSION = "1.0.2".freeze
+  VERSION = "1.0.1".freeze
 end

--- a/lib/flood_risk_engine/version.rb
+++ b/lib/flood_risk_engine/version.rb
@@ -1,3 +1,3 @@
 module FloodRiskEngine
-  VERSION = "1.0.1".freeze
+  VERSION = "1.0.2".freeze
 end


### PR DESCRIPTION
We the adition of the OS Places notice and T&C's to the engine (see a1e3e09), we need to update the version and tag the engine, so we can then update the [front office](https://github.com/EnvironmentAgency/flood-risk-front-office) and [back office](https://github.com/EnvironmentAgency/flood-risk-back-office) to bring in the changes.